### PR TITLE
Auto-FOX 0.6.20

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
+0.6.20
+******
+* Cleaned up how PES descriptors are generated & stored in the ``ARMC()`` class.
+
 
 0.6.19
 ******

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 0.6.20
 ******
 * Cleaned up how PES descriptors are generated & stored in the ``ARMC()`` class.
+* Atom names specified in .PSF files are now accessible by ``MultiMolecule()`` instances
+  during the ARMC procedure.
 
 
 0.6.19

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 * Cleaned up how PES descriptors are generated & stored in the ``ARMC()`` class.
 * Atom names specified in .PSF files are now accessible by ``MultiMolecule()`` instances
   during the ARMC procedure.
+* Generalized ``dekekulize()`` to work for all non-integer bond orders; not just ``1.5``.
 
 
 0.6.19

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.6.19'
+__version__ = '0.6.20'

--- a/FOX/armc_functions/mc_post_process.py
+++ b/FOX/armc_functions/mc_post_process.py
@@ -1,0 +1,72 @@
+"""
+FOX.armc_functions.mc_post_process
+==================================
+
+Callables for post-processing :class:`MultiMolecule` instances produced by :class:`MonteCarlo`.
+
+Index
+-----
+.. currentmodule:: FOX.armc_functions.mc_post_process
+.. autosummary::
+    AtomsFromPSF
+
+API
+---
+.. autoclass:: AtomsFromPSF
+
+"""
+
+from typing import Iterable, MutableSequence, Optional, MutableMapping
+
+from ..io.read_psf import PSFContainer
+from ..classes.multi_mol import MultiMolecule
+
+__all__ = ['AtomsFromPSF']
+
+AtomMapping = MutableMapping[str, MutableSequence[int]]
+
+
+class AtomsFromPSF:
+    r"""A callable for updating the atoms of a :class:`MultiMolecule` instances.
+
+    Examples
+    --------
+    .. code:: python
+
+        >>> from typing import Callable
+        >>> from FOX import PSFContainer, MultiMolecule
+
+        >>> psf_list = [PSFContainer(...), PSFContainer(...), PSFContainer(...)]
+        >>> atoms_from_psf: Callable = AtomsFromPSF.from_psf(*psf_list)
+
+        >>> mol_list = [MultiMolecule(...), MultiMolecule(...), MultiMolecule(...)]
+        >>> atoms_from_psf(None, mol_list)
+
+    Parameters
+    ----------
+    \*atom_dict : :class:`dict` [:class:`str`, :class:`list` [:class:`int`]]
+        One or more dictionaries with atomic symbols as keys and
+        lists of matching atomic indices as values.
+
+    """
+
+    @classmethod
+    def from_psf(cls, *psf: PSFContainer) -> 'AtomsFromPSF':
+        """Construct a :class:`AtomsFromPsf` instance from one or more :class:`PSFContainer`."""
+        try:
+            return cls(*[i.to_atom_dict() for i in psf])
+        except AttributeError as ex:
+            raise TypeError("'psf' expected one or more PSFContainers; "
+                            f"{ex}").with_traceback(ex.__traceback__)
+
+    def __init__(self, *atom_dict: AtomMapping) -> None:
+        """Initialize the :class:`AtomsFromPsf` instance."""
+        self.atom_dict = atom_dict
+
+    def __call__(self, mol_list: Optional[Iterable[MultiMolecule]],
+                 mc: Optional['MonteCarlo'] = None) -> None:
+        """Update the :attr:`MultiMolecule.atoms` of **mol_list**."""
+        if mol_list is None:
+            return
+        for atom_dict, mol in zip(self.atom_dict, mol_list):
+            mol.atoms.update(atom_dict)

--- a/FOX/armc_functions/sanitization.py
+++ b/FOX/armc_functions/sanitization.py
@@ -17,14 +17,15 @@ import pandas as pd
 
 from scm.plams import Settings, Molecule
 
+from .mc_post_process import AtomsFromPSF
+from .schemas import (
+    get_pes_schema, schema_armc, schema_move, schema_job, schema_param, schema_hdf5, schema_psf
+)
 from ..io.read_psf import PSFContainer, overlay_str_file, overlay_rtf_file
 from ..classes.multi_mol import MultiMolecule
 from ..functions.utils import get_template, dict_to_pandas, get_atom_count, _get_move_range
 from ..functions.cp2k_utils import set_keys, set_subsys_kind
 from ..functions.molecule_utils import fix_bond_orders
-from ..armc_functions.schemas import (
-    get_pes_schema, schema_armc, schema_move, schema_job, schema_param, schema_hdf5, schema_psf
-)
 
 __all__ = ['init_armc_sanitization']
 
@@ -57,6 +58,9 @@ def init_armc_sanitization(dct: Mapping) -> Settings:
     _parse_param(s, job)
     job.psf = _parse_psf(s, job.path)
     _parse_preopt(s)
+
+    if job.get('psf', None) is not None:
+        s['pes_post_process'] = [AtomsFromPSF.from_psf(*job['psf'])]
     return s, pes, job
 
 

--- a/FOX/classes/armc.py
+++ b/FOX/classes/armc.py
@@ -35,11 +35,11 @@ from ..logger import Plams2Logger, get_logger
 from ..io.hdf5_utils import (
     create_hdf5, to_hdf5, create_xyz_hdf5, _get_filename_xyz, hdf5_clear_status
 )
-from ..io.file_container import NullContext
 from ..functions.utils import get_template
-from ..armc_functions.sanitization import init_armc_sanitization
-from ..armc_functions.df_to_dict import df_to_dict
+from ..io.file_container import NullContext
 from ..armc_functions.guess import guess_param
+from ..armc_functions.df_to_dict import df_to_dict
+from ..armc_functions.sanitization import init_armc_sanitization
 
 __all__ = ['ARMC', 'run_armc']
 
@@ -261,11 +261,7 @@ class ARMC(MonteCarlo):
                 pass
 
         # The molecule block
-        s.molecule = []
-        for i, mol in enumerate(self.molecule):
-            name = os.path.join(s.job.path, f'mol.{i}.xyz')
-            s.molecule.append(name)
-            mol.as_xyz(name)
+        s.molecule = [mol.properties.filename for mol in self.molecule]
 
         # The pes block
         for name, partial in self.pes.items():

--- a/FOX/classes/monte_carlo.py
+++ b/FOX/classes/monte_carlo.py
@@ -150,7 +150,7 @@ class MonteCarlo(AbstractDataClass, abc.Mapping):
         else:
             self._pes_post_process = (value,)
 
-    _PRIVATE_ATTR = frozenset({'_plams_molecule'})
+    _PRIVATE_ATTR = frozenset({'_plams_molecule', 'job_cache'})
 
     def __init__(self, molecule: Union[MultiMolecule, Iterable[MultiMolecule]],
                  param: pd.DataFrame,

--- a/FOX/classes/monte_carlo.py
+++ b/FOX/classes/monte_carlo.py
@@ -137,6 +137,19 @@ class MonteCarlo(AbstractDataClass, abc.Mapping):
         else:
             self._logger = get_logger(self.__class__.__name__, handler_type=logging.StreamHandler)
 
+    @property
+    def pes_post_process(self) -> Tuple[Callable, ...]:
+        return self._pes_post_process
+
+    @pes_post_process.setter
+    def pes_post_process(self, value: Optional[Callable, Iterable[Callable]]) -> None:
+        if value is None:
+            self._pes_post_process = ()
+        elif isinstance(value, abc.Iterable):
+            self._pes_post_process = tuple(value)
+        else:
+            self._pes_post_process = (value,)
+
     _PRIVATE_ATTR = frozenset({'_plams_molecule'})
 
     def __init__(self, molecule: Union[MultiMolecule, Iterable[MultiMolecule]],
@@ -149,7 +162,8 @@ class MonteCarlo(AbstractDataClass, abc.Mapping):
                  apply_move: Callable[[float, float], float] = np.multiply,
                  move_range: Optional[np.ndarray] = None,
                  keep_files: bool = False,
-                 logger: Optional[logging.Logger] = None) -> None:
+                 logger: Optional[logging.Logger] = None,
+                 pes_post_process: Optional[Callable, Iterable[Callable]] = None) -> None:
         """Initialize a :class:`MonteCarlo` instance."""
         super().__init__()
 

--- a/FOX/classes/multi_mol.py
+++ b/FOX/classes/multi_mol.py
@@ -20,10 +20,12 @@ API
 """
 
 import copy
+from os import PathLike
 from collections import abc
 from itertools import chain, combinations_with_replacement, zip_longest, islice, repeat
 from typing import (
-    Sequence, Optional, Union, List, Hashable, Callable, Iterable, Dict, Tuple, Any, Mapping
+    Sequence, Optional, Union, List, Hashable, Callable, Iterable, Dict, Tuple, Any, Mapping,
+    AnyStr
 )
 
 import numpy as np
@@ -2199,7 +2201,7 @@ class MultiMolecule(_MultiMolecule):
         return cls(coords, **kwargs)
 
     @classmethod
-    def from_xyz(cls, filename: str,
+    def from_xyz(cls, filename: Union[AnyStr, PathLike],
                  bonds: Optional[np.ndarray] = None,
                  properties: Optional[dict] = None) -> 'MultiMolecule':
         """Construct a :class:`.MultiMolecule` instance from a (multi) .xyz file.
@@ -2229,10 +2231,13 @@ class MultiMolecule(_MultiMolecule):
 
         """
         coords, atoms, comments = read_multi_xyz(filename)
-        return cls(coords, atoms, bonds, {'comments': comments})
+        ret = cls(coords, atoms, bonds, properties)
+        ret.properties['comments'] = comments
+        ret.properties['filename'] = filename
+        return ret
 
     @classmethod
-    def from_kf(cls, filename: str,
+    def from_kf(cls, filename: Union[AnyStr, PathLike],
                 bonds: Optional[np.ndarray] = None,
                 properties: Optional[dict] = None) -> 'MultiMolecule':
         """Construct a :class:`.MultiMolecule` instance from a KF binary file.
@@ -2258,4 +2263,6 @@ class MultiMolecule(_MultiMolecule):
             A :class:`.MultiMolecule` instance constructed from **filename**.
 
         """
-        return cls(*read_kf(filename), bonds, properties)
+        ret = cls(*read_kf(filename), bonds, properties)
+        ret.properties['filename'] = filename
+        return ret

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@
 
 
 ##################################################
-Automated Forcefield Optimization Extension 0.6.19
+Automated Forcefield Optimization Extension 0.6.20
 ##################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ copyright = f'{year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.6.19'  # The full version, including alpha/beta/rc tags.
+release = '0.6.20'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 

--- a/tests/test_armc.py
+++ b/tests/test_armc.py
@@ -41,10 +41,9 @@ def test_to_yaml() -> None:
 
         for k, v1 in armc1.pes.items():
             v2 = armc2.pes[k]
-            for p1, p2 in zip(v1, v2):
-                assertion.is_(p1.func, p2.func)
-                assertion.eq(p1.keywords, p2.keywords)
-                np.testing.assert_allclose(p1.ref.values, p2.ref.values)
+            assertion.is_(v1.func, v2.func)
+            assertion.eq(v1.keywords, v2.keywords)
+            np.testing.assert_allclose(v1.ref.values, v2.ref.values)
 
         np.testing.assert_allclose(armc1.param['param'], armc2.param['param'])
         np.testing.assert_allclose(armc1.param['min'], armc2.param['min'])

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -105,9 +105,9 @@ def test_cp2k_md():
             np.testing.assert_array_equal(v1, v2)
 
     assertion.isinstance(armc.pes, dict)
-    assertion.contains(armc.pes, 'rdf')
-    assertion.is_(armc.pes['rdf'][0].func, MultiMolecule.init_rdf)
-    assertion.eq(armc.pes['rdf'][0].keywords, {'atom_subset': ['Cd', 'Se', 'O']})
+    assertion.contains(armc.pes, 'rdf.0')
+    assertion.is_(armc.pes['rdf.0'].func, MultiMolecule.init_rdf)
+    assertion.eq(armc.pes['rdf.0'].keywords, {'atom_subset': ['Cd', 'Se', 'O']})
 
     assertion.eq(armc.phi, 1.0)
     assertion.is_(armc.preopt_settings, None)


### PR DESCRIPTION
* Cleaned up how PES descriptors are generated, stored and processed in the ``ARMC()`` class.
* Atom names specified in .PSF files are now accessible by ``MultiMolecule()`` instances
  during the ARMC procedure.
* Generalized ``dekekulize()`` to work for all non-integer bond orders; not just ``1.5``.