### PR TITLE
Auto-FOX 0.6.21

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
+
+0.6.21
+******
+* Fixed an issue where a ``MultiMolecule()`` couldn't be converted into a ``Molecule()``.
+* Upped the version requirement from the ``assertionlib`` package to >= 2.
+
+
 0.6.20
 ******
 * Cleaned up how PES descriptors are generated & stored in the ``ARMC()`` class.

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.6.20'
+__version__ = '0.6.21'

--- a/FOX/classes/monte_carlo.py
+++ b/FOX/classes/monte_carlo.py
@@ -405,11 +405,11 @@ class MonteCarlo(AbstractDataClass, abc.Mapping):
 
             # Run an MD calculation
             if preopt_accept and preopt_mol_list is not None:
-                return self._md(preopt_mol_list)
+                return self._md(mol.as_Molecule(-1)[0] for mol in preopt_mol_list)
             return None
 
         else:  # preoptimization is disabled
-            return self._md(self.molecule)
+            return self._md(self._plams_molecule)
 
     def _md_preopt(self) -> Optional[List[MultiMolecule]]:
         """Peform a geometry optimization.
@@ -447,16 +447,15 @@ class MonteCarlo(AbstractDataClass, abc.Mapping):
             mol_list.append(mol)
         return mol_list
 
-    def _md(self, mol_preopt: Iterable[MultiMolecule]) -> Optional[List[MultiMolecule]]:
+    def _md(self, mol_preopt: Iterable[Molecule]) -> Optional[List[MultiMolecule]]:
         """Peform a molecular dynamics simulation (MD).
 
         Simulations are performed on all molecules in **mol_preopt**.
 
         Parameters
         ----------
-        mol_preopt : |list|_ [|FOX.MultiMolecule|_]
-            An iterable consisting of :class:`.MultiMolecule` instance(s) constructed from
-            geometry pre-optimization(s) (see :meth:`._md_preopt`).
+        mol_preopt : |list|_ [|Molecule|_]
+            An iterable consisting of PLAMS Molecules.
 
         Returns
         -------
@@ -467,9 +466,8 @@ class MonteCarlo(AbstractDataClass, abc.Mapping):
         """
         name = self.job_name
         job_type = self.job_type
-        mol_generator = (mol.as_Molecule(-1)[0] for mol in mol_preopt)
         jobs = [job_type(name=name, molecule=mol, settings=s) for
-                mol, s in zip(mol_generator, self.md_settings)]
+                mol, s in zip(mol_preopt, self.md_settings)]
 
         # Run MD
         mol_list = []

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@
 
 
 ##################################################
-Automated Forcefield Optimization Extension 0.6.20
+Automated Forcefield Optimization Extension 0.6.21
 ##################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ copyright = f'{year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.6.20'  # The full version, including alpha/beta/rc tags.
+release = '0.6.21'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'scipy',
         'pandas',
         'schema',
-        'AssertionLib>=1.0',
+        'AssertionLib>=2.0',
         'plams@git+https://github.com/SCM-NV/PLAMS@master'
     ],
     setup_requires=[

--- a/tests/test_multi_mol.py
+++ b/tests/test_multi_mol.py
@@ -12,6 +12,7 @@ from FOX.functions.utils import get_template
 
 MOL = MultiMolecule.from_xyz(example_xyz)
 PATH = join('tests', 'test_files')
+PATH = '/Users/basvanbeek/Documents/GitHub/auto-FOX/tests/test_files'
 
 
 def test_delete_atoms():
@@ -52,13 +53,13 @@ def test_reset_origin():
     mol = MOL.copy()
 
     mol.reset_origin()
-    assertion.allclose(mol.mean(axis=1).sum(), 0.0)
+    assertion.allclose(mol.mean(axis=1).sum(), 0.0, abs_tol=10**-8)
 
     mol_new = mol.reset_origin(mol_subset=1000, inplace=False)
-    assertion.allclose(mol_new[0:1000].mean(axis=1).sum(), 0.0)
+    assertion.allclose(mol_new[0:1000].mean(axis=1).sum(), 0.0, abs_tol=10**-8)
 
     mol_new = mol.reset_origin(atom_subset=slice(0, 100), inplace=False)
-    assertion.allclose(mol_new[:, 0:100].mean(axis=1).sum(), 0.0)
+    assertion.allclose(mol_new[:, 0:100].mean(axis=1).sum(), 0.0, abs_tol=10**-8)
 
 
 def test_sort():
@@ -99,7 +100,7 @@ def test_get_center_of_mass():
     center_of_mass = mol.get_center_of_mass()
     mol -= center_of_mass[:, None, :]
     center_of_mass = mol.get_center_of_mass()
-    assertion.allclose(np.abs(center_of_mass.mean()), 0.0)
+    assertion.allclose(np.abs(center_of_mass.mean()), 0.0, abs_tol=10**-8)
 
 
 def test_get_bonds_per_atom():
@@ -256,7 +257,7 @@ def test_from_mass_weighted():
 
     mol_new = mol.as_mass_weighted()
     mol_new.from_mass_weighted()
-    assertion.allclose(np.abs((mol_new - mol).mean()), 0.0)
+    assertion.allclose(np.abs((mol_new - mol).mean()), 0.0, abs_tol=10**-8)
 
 
 def test_as_Molecule():

--- a/tests/test_multi_mol.py
+++ b/tests/test_multi_mol.py
@@ -12,7 +12,6 @@ from FOX.functions.utils import get_template
 
 MOL = MultiMolecule.from_xyz(example_xyz)
 PATH = join('tests', 'test_files')
-PATH = '/Users/basvanbeek/Documents/GitHub/auto-FOX/tests/test_files'
 
 
 def test_delete_atoms():


### PR DESCRIPTION
* Fixed an issue where a ``MultiMolecule()`` couldn't be converted into a ``Molecule()``.
* Upped the version requirement from the ``assertionlib`` package to >= 2.