### PR TITLE
More memory-related improvements

### DIFF
--- a/FOX/ff/lj_calculate.py
+++ b/FOX/ff/lj_calculate.py
@@ -181,7 +181,7 @@ def get_V(mol: MultiMolecule, slice_mapping: SliceMapping,
 
     for atoms, ij in slice_mapping.items():
         charge, epsilon, sigma = prm_mapping[atoms]
-        contains_core = core_atoms.intersection(atoms)
+        contains_core = bool(core_atoms.intersection(atoms))
 
         dmat_size = len(ij[0]) * len(ij[1])  # The size of a single (2D) distance matrix
         slice_iterator = _get_slice_iterator(len(mol), dmat_size, max_array_size)

--- a/FOX/ff/lj_calculate.py
+++ b/FOX/ff/lj_calculate.py
@@ -24,6 +24,7 @@ intra-moleculair interactions.
 """
 
 import math
+import functools
 from typing import Mapping, Tuple, Sequence, Optional, Iterable, Union, Generator
 
 import numpy as np
@@ -49,7 +50,8 @@ def get_non_bonded(mol: Union[str, MultiMolecule],
                    prm: Union[None, str, PRMContainer] = None,
                    rtf: Optional[str] = None,
                    cp2k_settings: Optional[Mapping] = None,
-                   max_array_size: int = 10**8) -> pd.DataFrame:
+                   max_array_size: int = 10**8,
+                   distance_upper_bound: float = np.inf, k: int = 20) -> pd.DataFrame:
     r"""Collect forcefield parameters and calculate all non-covalent interactions in **mol**.
 
     Forcefield parameters (*i.e.* charges and Lennard-Jones :math:`\sigma` and
@@ -89,6 +91,14 @@ def get_non_bonded(mol: Union[str, MultiMolecule],
         NumPy's vectorized operations will be (partially) substituted for for-loops if the
         array size is exceeded.
 
+    distance_upper_bound : :class:`float`
+        Consider only atom-pairs within this distance.
+        Using ``inf`` will default to the full, untracted, distance matrix.
+
+    k : :class:`int`
+        The (maximum) number of to-be considered atom-pairs.
+        Only relevant when **distance_upper_bound** is not set ``inf``.
+
     Returns
     -------
     :class:`pandas.DataFrame`
@@ -103,7 +113,11 @@ def get_non_bonded(mol: Union[str, MultiMolecule],
     :func:`get_V`
         Calculate all non-covalent interactions averaged over all molecules in **mol**.
 
+    :class:`cKDTree<scipy.spatial.cKDTree>
+        kd-tree for quick nearest-neighbor lookup.
+
     """
+    # Parse input parameters
     if not isinstance(psf, PSFContainer):
         psf = PSFContainer.read(psf)
 
@@ -113,6 +127,7 @@ def get_non_bonded(mol: Union[str, MultiMolecule],
         mol = mol.copy(deep=False)
     mol.atoms = mol_atoms = psf.to_atom_dict()
 
+    # Create the parameter DataFrame
     prm_df = LJDataFrame(index=mol_atoms.keys())
     prm_df.overlay_psf(psf)
     if prm is not None:
@@ -120,12 +135,15 @@ def get_non_bonded(mol: Union[str, MultiMolecule],
     if cp2k_settings is not None:
         prm_df.overlay_cp2k_settings(cp2k_settings)
 
+    # Define atom subsets
     slice_dict = {}
     for i, j in prm_df.index:
         try:
             slice_dict[i, j] = mol_atoms[i], mol_atoms[j]
         except KeyError:
             pass
+
+    # Calculate and return the potential energies
     core_atoms = set(psf.atom_type[psf.residue_id == 1])
     ligand_count = psf.residue_id.max() - 1
     return get_V(mol, slice_dict, prm_df.loc, ligand_count, core_atoms=core_atoms)
@@ -134,7 +152,8 @@ def get_non_bonded(mol: Union[str, MultiMolecule],
 def get_V(mol: MultiMolecule, slice_mapping: SliceMapping,
           prm_mapping: PrmMapping, ligand_count: int,
           core_atoms: Optional[Iterable[str]] = None,
-          max_array_size: int = 10**8) -> pd.DataFrame:
+          max_array_size: int = 10**8,
+          distance_upper_bound: float = np.inf, k: int = 20) -> pd.DataFrame:
     r"""Calculate all non-covalent interactions averaged over all molecules in **mol**.
 
     Parameters
@@ -161,6 +180,13 @@ def get_V(mol: MultiMolecule, slice_mapping: SliceMapping,
         NumPy's vectorized operations will be (partially) substituted for for-loops if the
         array size is exceeded.
 
+    distance_upper_bound : :class:`float`
+        Consider only atom-pairs within this distance.
+
+    k : :class:`int`
+        The (maximum) number of to-be considered atom-pairs.
+        Only relevant when **distance_upper_bound** is not set ``inf``.
+
     Returns
     -------
     :class:`pandas.DataFrame`
@@ -180,16 +206,25 @@ def get_V(mol: MultiMolecule, slice_mapping: SliceMapping,
         columns=pd.Index(['elstat', 'lj'], name='au')
     )
 
+    # Specify the function for calculating the distance matrices
+    if np.isinf(distance_upper_bound):
+        dist_func = _get_dist
+        k = None
+    else:
+        dist_func = functools.partial(_get_kd_dist, k=k, distance_upper_bound=distance_upper_bound)
+
     for atoms, ij in slice_mapping.items():
         charge, epsilon, sigma = prm_mapping[atoms]
         contains_core = bool(core_atoms.intersection(atoms))
 
-        # dmat_size = len(ij[0]) * len(ij[1])  # The size of a single (2D) distance matrix
-        dmat_size = len(ij[0]) * 15  # The dist mat is limited to the kth nearest neighbour
+        # Construct a :class:`slice` iterator based on the expected array size.
+        # Precaution against creating arrays too large to hold in memory
+        dmat_size = len(ij[0]) * (k or len(ij[1]))
         slice_iterator = _get_slice_iterator(len(mol), dmat_size, max_array_size)
 
+        # Construct the distance matrices and calculate the potential energies
         for mol_subset in slice_iterator:
-            dist = _get_kd_dist(mol, ij, ligand_count, contains_core, mol_subset=mol_subset)
+            dist = dist_func(mol, ij, ligand_count, contains_core, mol_subset=mol_subset)
             df.at[atoms, 'elstat'] += get_V_elstat(charge, dist)
             df.at[atoms, 'lj'] += get_V_lj(sigma, epsilon, dist)
             del dist
@@ -216,38 +251,34 @@ def _get_dist(mol: MultiMolecule, ij: np.ndarray, ligand_count: int,
 
 
 def _get_kd_dist(mol: MultiMolecule, ij: np.ndarray, ligand_count: int,
-                 contains_core: bool, mol_subset: Optional[slice]) -> np.ndarray:
+                 contains_core: bool, mol_subset: Optional[slice],
+                 k: int = 20, distance_upper_bound: float = 10.0) -> np.ndarray:
     """Construct an array of truncated distance matrices for :func:`get_V`."""
     i_ar, j_ar = ij
-    k = 15
-
     mol1 = mol[mol_subset, i_ar]
     mol2 = mol[mol_subset, j_ar]
 
-    if contains_core:
-        dist = np.empty((len(mol1), len(i_ar), k), dtype=float)
-        for n, (xyz1, xyz2) in enumerate(zip(mol1, mol2)):
-            tree = cKDTree(xyz2)
-            dist[n] = tree.query(xyz1, k=k, distance_upper_bound=10)[0]
+    # Fill the (truncated) distance tensor
+    dist = np.empty((len(mol1), len(i_ar), k), dtype=float)
+    idx = np.empty_like(dist, dtype=int)
+    for n, (xyz1, xyz2) in enumerate(zip(mol1, mol2)):
+        tree = cKDTree(xyz2)
+        dist[n], idx[n] = tree.query(xyz1, k=k, distance_upper_bound=distance_upper_bound)
 
-    else:
-        dist = np.empty((len(mol1), len(i_ar), k), dtype=float)
-        idx = np.empty_like(dist, dtype=int)
-        for n, (xyz1, xyz2) in enumerate(zip(mol1, mol2)):
-            tree = cKDTree(xyz2)
-            dist[n], idx[n] = tree.query(xyz1, k=k, distance_upper_bound=10)
-
+    # Set all inter-ligand interaction to np.nan
+    if not contains_core:
         lig_len = len(i_ar) // ligand_count
 
-        a, b, c = idx.shape
-        idx.shape = a, b // lig_len, lig_len, c
+        ax1, ax2, ax3 = idx.shape
+        idx.shape = ax1, ax2 // lig_len, lig_len, ax3
         idx -= np.arange(0, len(i_ar), lig_len)[None, ..., None, None]
-        idx.shape = a, b, c
+        idx.shape = ax1, ax2, ax3
 
         dist[np.isin(idx, np.arange(lig_len))] = np.nan
 
+    # Set zero and infinity to np.nan
     dist[dist == 0.0] = np.nan
-    dist[dist == np.inf] = np.nan
+    dist[np.isinf(dist)] = np.nan
     return dist
 
 

--- a/FOX/ff/lj_calculate.py
+++ b/FOX/ff/lj_calculate.py
@@ -187,7 +187,6 @@ def get_V(mol: MultiMolecule, slice_mapping: SliceMapping,
         dmat_size = len(ij[0]) * len(ij[1])  # The size of a single (2D) distance matrix
         slice_iterator = _get_slice_iterator(len(mol), dmat_size, max_array_size)
 
-        print(f'{repr(atoms)},')
         for mol_subset in slice_iterator:
             dist = _get_kd_dist(mol, ij, ligand_count, contains_core, mol_subset=mol_subset)
             df.at[atoms, 'elstat'] += get_V_elstat(charge, dist)
@@ -228,12 +227,17 @@ def _get_kd_dist(mol: MultiMolecule, ij: np.ndarray, ligand_count: int,
     mol2 = mol[mol_subset, j]
 
     dist = np.empty((len(mol1), len(i), k), dtype=float)
+    idx_ar = np.empty_like(dist, dtype=int)
     for idx, (xyz1, xyz2) in enumerate(zip(mol1, mol2)):
         tree = cKDTree(xyz2)
-        dist[idx] = tree.query(xyz1, k=k, distance_upper_bound=10)[0]
+        dist[idx], idx_ar[idx] = tree.query(xyz1, k=k, distance_upper_bound=10)
 
-    dist[dist == 0.0] = np.nan
-    print(f'{np.count_nonzero(dist != np.inf) / np.product(dist.shape[:-1])},')
+    if contains_core:
+        dist[dist == 0.0] = np.nan
+    else:
+        i_len = len(i) // ligand_count
+        j_len = len(j) // ligand_count
+        idx_ar
 
     return dist
 

--- a/FOX/ff/lj_intra_calculate.py
+++ b/FOX/ff/lj_intra_calculate.py
@@ -32,7 +32,7 @@ import pandas as pd
 
 from scm.plams import Atom, Molecule, Units, PT
 
-from .lj_calculate import get_V_elstat, get_V_lj
+from .lj_calculate import get_V_elstat, get_V_lj, _get_slice_iterator
 from .lj_dataframe import LJDataFrame
 from .bonded_calculate import _dist
 from ..classes.multi_mol import MultiMolecule
@@ -44,7 +44,8 @@ __all__ = ['get_intra_non_bonded']
 
 def get_intra_non_bonded(mol: Union[str, MultiMolecule], psf: Union[str, PSFContainer],
                          prm: Union[str, PRMContainer],
-                         scale_elstat: float = 0.0, scale_lj: float = 1.0) -> LJDataFrame:
+                         scale_elstat: float = 0.0, scale_lj: float = 1.0,
+                         max_array_size: int = 10**8) -> LJDataFrame:
     r"""Collect forcefield parameters and calculate all non-covalent intra-ligand interactions in **mol**.
 
     Forcefield parameters (*i.e.* charges and Lennard-Jones :math:`\sigma` and
@@ -72,6 +73,11 @@ def get_intra_non_bonded(mol: Union[str, MultiMolecule], psf: Union[str, PSFCont
     scale_lj : :class:`float`
         Scaling factor to apply to all 1,4-nonbonded Lennard-Jones interactions.
         Serves the same purpose as the cp2k ``VDW_SCALE14`` keyword.
+
+    max_array_size : :class:`int`
+        The maximum number of elements within the to-be created NumPy array.
+        NumPy's vectorized operations will be (partially) substituted for for-loops if the
+        array size is exceeded.
 
     Returns
     -------
@@ -122,7 +128,8 @@ def get_intra_non_bonded(mol: Union[str, MultiMolecule], psf: Union[str, PSFCont
 
 
 def _fill_df(prm_df: pd.DataFrame, mol: MultiMolecule, core_atoms: np.ndarray,
-             depth_comparison: Callable[[int, int], bool] = operator.__ge__) -> None:
+             depth_comparison: Callable[[int, int], bool] = operator.__ge__,
+             max_array_size: int = 10**8) -> None:
     """Construct the distance matrix; calculate the potential and update the **prm_df** with the energies."""  # noqa
     ij = _get_idx(mol, core_atoms, depth_comparison=depth_comparison).T
     if not ij.any():
@@ -133,22 +140,24 @@ def _fill_df(prm_df: pd.DataFrame, mol: MultiMolecule, core_atoms: np.ndarray,
     symbol = mol.symbol[ij].T
     symbol.sort(axis=1)
 
-    # Construct the distance matrix
-    dist = _dist(mol, ij.T)
-    dist *= Units.conversion_ratio('angstrom', 'au')
+    len_mol = len(mol)
+    angstrom2au = Units.conversion_ratio('angstrom', 'au')
+
+    ij = ij.T
+    dmat_size = len(ij[0]) * len(ij[1])  # The size of a single (2D) distance matrix
+    slice_iterator = _get_slice_iterator(len_mol, dmat_size, max_array_size)
 
     # Calculate the potential energies
-    for idx, items in prm_df[['charge', 'epsilon', 'sigma']].iterrows():
-        idx_hash = sorted(hash(i) for i in idx)
-        dist_slice = dist[:, np.all(symbol == idx_hash, axis=1)]
+    for mol_subset in slice_iterator:
+        dist = _dist(mol[mol_subset] * angstrom2au, ij)  # Construct the distance matrix
 
-        charge, epsilon, sigma = items
-        prm_df.at[idx, 'elstat'] = get_V_elstat(items['charge'], dist_slice) / len(mol)
-        prm_df.at[idx, 'lj'] = get_V_lj(sigma, epsilon, dist_slice) / len(mol)
+        for idx, items in prm_df[['charge', 'epsilon', 'sigma']].iterrows():
+            idx_hash = sorted(hash(i) for i in idx)
+            dist_slice = dist[:, np.all(symbol == idx_hash, axis=1)]
 
-        # Prevent double counting when an atom-pair consists of identical atoms
-        if idx[0] == idx[1]:
-            prm_df.loc[idx, ['elstat', 'lj']] /= 2
+            charge, epsilon, sigma = items
+            prm_df.at[idx, 'elstat'] += get_V_elstat(charge, dist_slice) / len(mol)
+            prm_df.at[idx, 'lj'] += get_V_lj(sigma, epsilon, dist_slice) / len(mol)
 
 
 def _construct_df(mol: MultiMolecule, lig_atoms: np.ndarray,


### PR DESCRIPTION
* Added the option to calculate inter-ligand non-bonded interactions using truncated distance matrices.
* MD-slices are now automatically selected, based on array sizes, for the calculation on intra-ligand non-bonded interactions. Identical to https://github.com/nlesc-nano/auto-FOX/pull/77, expect for intra- rather than inter-ligand interactions.
* Fixed a bug where intra-ligand were computed at half the desired magnitude when  `atom1 == atom2`.