### PR TITLE
Auto-FOX 0.7.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+0.7.4
+*****
+* Increased the assertionlib version requirement to >= v2.1.
+* Generalized ``PRMContainer.overlay_cp2k_settings()`` to work for all
+  forcefield parameters (potentially) specified in CP2K settings.
+* Added the ``TypedMapping`` class, a baseclass for creating typed ``Mappings``,
+  *i.e.* Mappings with a set number of specific keys.
+* Exchange a number of ``Settings.__contains__()`` operations for ``Settings.get()``.
+
+
 0.7.3
 *****
 * Updated the default CP2K Settings template.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 * Increased the assertionlib version requirement to >= v2.1.
 * Generalized ``PRMContainer.overlay_cp2k_settings()`` to work for all
   forcefield parameters (potentially) specified in CP2K settings.
+* Added the ``PRMContainer.overlay_mapping()`` function for overlaying
+  an arbitrary (nested) Mapping with the ``PSFContainer``.
 * Added the ``TypedMapping`` class, a baseclass for creating typed ``Mappings``,
   *i.e.* Mappings with a set number of specific keys.
 * Exchange a number of ``Settings.__contains__()`` operations for ``Settings.get()``.

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.7.3'
+__version__ = '0.7.4'

--- a/FOX/frozen_mapping.py
+++ b/FOX/frozen_mapping.py
@@ -1,0 +1,102 @@
+"""
+FOX.classes.frozen_settings
+===========================
+
+A module which adds the :class:`.FrozenSettings` class.
+
+Index
+-----
+.. currentmodule:: FOX.classes.frozen_settings
+.. autosummary::
+    FrozenSettings
+
+API
+---
+.. autoclass:: FOX.classes.frozen_settings.FrozenSettings
+    :members:
+    :private-members:
+    :special-members:
+
+"""
+
+from collections import abc
+from types import MappingProxyType
+from typing import (Any, Iterator, Optional, Callable, TypeVar, KeysView, ItemsView, ValuesView,
+                    ClassVar, FrozenSet)
+
+from assertionlib.dataclass import AbstractDataClass
+
+__all__ = ['FrozenMapping']
+
+KT = TypeVar('KT', bound=str)
+KV = TypeVar('KV')
+
+
+class FrozenMapping(AbstractDataClass, abc.Mapping):
+    _PRIVATE_ATTR: ClassVar[FrozenSet[str]] = frozenset({'_view'})
+
+    def __init__(self) -> None:
+        super().__setattr__('_view', {})
+        super().__init__()
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Implement :code:`setattr(self, name, value)`."""
+        if name not in self._PRIVATE_ATTR:
+            self._view[name] = value
+        super().__setattr__(name, value)
+
+    def __delattr__(self, name: str) -> None:
+        """Implement :code:`delattr(self, name)`."""
+        if name not in self._PRIVATE_ATTR:
+            del self._view[name]
+        super().__delattr__(name)
+
+    @property
+    def view(self):
+        """Return a read-only view of all non-private instance attributes."""
+        return MappingProxyType(self._view)
+
+    @property
+    def __bool__(self) -> Callable[[], bool]:
+        """Get the :meth:`__bool__<types.MappingProxyType.__bool__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        return self.view.__bool__
+
+    @property
+    def __getitem__(self) -> Callable[[KT], KV]:
+        """Get the :meth:`__getitem__<types.MappingProxyType.__getitem__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        return self.view.__getitem__
+
+    @property
+    def __iter__(self) -> Callable[[], Iterator[KT]]:
+        """Get the :meth:`__iter__<types.MappingProxyType.__iter__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        return self.view.__iter__
+
+    @property
+    def __len__(self) -> Callable[[], int]:
+        """Get the :meth:`__len__<types.MappingProxyType.__len__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        return self.view.__len__
+
+    @property
+    def __contains__(self) -> Callable[[KT], bool]:
+        """Get the :meth:`__contains__<types.MappingProxyType.__contains__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        return self.view.__contains__
+
+    @property
+    def get(self) -> Callable[[KT, Optional[Any]], KV]:
+        """Get the :meth:`get<types.MappingProxyType.get>` method of :attr:`FrozenMapping.view`."""  # noqa
+        return self.view.get
+
+    @property
+    def keys(self) -> Callable[[], KeysView[KT]]:
+        """Get the :meth:`keys<types.MappingProxyType.keys>` method of :attr:`FrozenMapping.view`."""  # noqa
+        return self.view.keys
+
+    @property
+    def items(self) -> Callable[[], ItemsView[KT, KV]]:
+        """Get the :meth:`items<types.MappingProxyType.items>` method of :attr:`FrozenMapping.view`."""  # noqa
+        return self.view.items
+
+    @property
+    def values(self) -> Callable[[], ValuesView[KV]]:
+        """Get the :meth:`values<types.MappingProxyType.values>` method of :attr:`FrozenMapping.view`."""  # noqa
+        return self.view.values

--- a/FOX/functions/cp2k_utils.py
+++ b/FOX/functions/cp2k_utils.py
@@ -21,16 +21,19 @@ Units.energy['k'] = Units.energy['kelvin'] = (
 
 #: Map CP2K units to PLAMS units.
 UNIT_MAP: Mapping[str, str] = MappingProxyType({
-    '[hartree]': 'Hartree',
+    '[hartree]': 'hartree',
     '[ev]': 'eV',
     '[kcalmol]': 'kcal/mol',
     '[kjmol]': 'kj/mol',
     '[k_e]': 'kelvin',
 
-    '[bohr]': 'Bohr',
+    '[bohr]': 'bohr',
     '[pm]': 'pm',
     '[nm]': 'nm',
-    '[angstrom]': 'Angstrom'
+    '[angstrom]': 'angstrom',
+
+    '[rad]': 'radian',
+    '[deg]': 'degree'
 })
 
 

--- a/FOX/io/cp2k_to_prm.py
+++ b/FOX/io/cp2k_to_prm.py
@@ -1,0 +1,131 @@
+from typing import Optional, Iterable, Callable, FrozenSet, TypeVar, Tuple, Union, Type, Any
+from collections import abc
+
+from ..frozen_mapping import FrozenMapping
+
+__all__ = ['PRMMapping', 'CP2K_TO_PRM']
+
+KV = TypeVar('KV')
+NoneType = type(None)
+PostProcess = Callable[[float], float]
+
+
+class PRMMapping(FrozenMapping):
+    """A mapping providing tools for converting CP2K settings to .prm-compatible values.
+
+    Attributes
+    ----------
+    name : :class:`str`
+        The name of the :class:`PRMContainer<FOX.io.read_prm.PRMContainer>` attribute.
+
+    columns : :class:`int` or :class:`Iterable<collections.abc.Iterable>` [:class:`int`]
+        The names relevant :class:`PRMContainer<FOX.io.read_prm.PRMContainer>`
+        DataFrame columns.
+
+    key_path : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+        The path of CP2K Settings keys leading to the property of interest.
+
+    key : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+        The key(s) within :attr:`PRMMapping.key_path` containg the actual properties of interest,
+        *e.g.* ``"epsilon"`` and ``"sigma"``.
+
+    unit : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+        The desired output unit.
+
+    default_unit : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+        The default unit as utilized by CP2K.
+
+    post_process : :class:`Callable<collections.abc.Callable>` or :class:`Iterable<collections.abc.Iterable>` [:class:`Callable<collections.abc.Callable>`]
+        Callables for post-processing the value of interest.
+        Set a particular callable to ``None`` to disable post-processing.
+
+    """  # noqa
+
+    def __init__(self, name: str,
+                 columns: Union[int, Iterable[int]],
+                 key_path: Union[str, Iterable[str]],
+                 key: Union[str, Iterable[str]],
+                 unit: Union[str, Iterable[str]],
+                 default_unit: Union[None, str, Iterable[Optional[str]]],
+                 post_process: Union[None, PostProcess, Iterable[Optional[PostProcess]]]) -> None:
+        super().__init__()
+        self.name = name
+        self.columns = self._to_tuple(columns, int)
+        self.key_path = self._to_tuple(key_path, str)
+        self.key = self._to_tuple(key, str)
+        self.unit = self._to_tuple(unit, str)
+        self.default_unit = self._to_tuple(default_unit, (str, NoneType))
+        self.post_process = self._to_tuple(post_process, (abc.Callable, NoneType))
+
+    @staticmethod
+    def _to_tuple(value: Union[KV, Iterable[KV]],
+                  def_type: Union[Type[KV], Tuple[Type[KV], ...]]) -> Tuple[KV, ...]:
+        if isinstance(value, tuple):
+            return value
+        elif isinstance(value, def_type):
+            return (value,)
+        return tuple(value)
+
+
+def sigma_to_r2(sigma: float) -> float:
+    r"""Convert :math:`\sigma` into :math:`|frac{1}{2} R`."""
+    R = sigma * 2**(1/6)
+    return R / 2
+
+
+def return_zero(value: Any) -> int:
+    """Return :math:`0`."""
+    return 0
+
+
+#: A :class:`frozenset`
+CP2K_TO_PRM: FrozenSet[PRMMapping] = frozenset({
+    PRMMapping(name='nbfix', columns=[2, 3],
+               key_path=('input', 'force_eval', 'mm', 'forcefield', 'nonbonded', 'lennard-jones'),
+               key=('epsilon', 'sigma'),
+               unit=('kcal/mol', 'angstrom'),
+               default_unit=('kcal/mol', 'kelvin'),
+               post_process=(None, sigma_to_r2)),
+
+    PRMMapping(name='nbfix', columns=[4, 5],
+               key_path=('input', 'force_eval', 'mm', 'forcefield', 'nonbonded14', 'lennard-jones'),
+               key=('epsilon', 'sigma'),
+               unit=('kcal/mol', 'angstrom'),
+               default_unit=('kcal/mol', 'kelvin'),
+               post_process=(None, sigma_to_r2)),
+
+    PRMMapping(name='bonds', columns=[2, 3],
+               key_path=('input', 'force_eval', 'mm', 'forcefield', 'bond'),
+               key=('k', 'r0'),
+               unit=('kcal/mol/A**2', 'angstrom'),
+               default_unit=('internal_cp2k', 'bohr'),  # TODO: internal_cp2k ?????????
+               post_process=(None, None)),
+
+    PRMMapping(name='angles', columns=[3, 4],
+               key_path=('input', 'force_eval', 'mm', 'forcefield', 'bend'),
+               key=('k', 'theta0'),
+               unit=('kcal/mol', 'degree'),
+               default_unit=('hartree', 'radian'),
+               post_process=(None, None)),
+
+    PRMMapping(name='angles', columns=[5, 6],
+               key_path=('input', 'force_eval', 'mm', 'forcefield', 'bend', 'ub'),
+               key=('k', 'r0'),
+               unit=('kcal/mol/A**2', 'angstrom'),
+               default_unit=('internal_cp2k', 'bohr'),  # TODO: internal_cp2k ?????????
+               post_process=(None, None)),
+
+    PRMMapping(name='dihedrals', columns=[4, 5, 6],
+               key_path=('input', 'force_eval', 'mm', 'forcefield', 'torsion'),
+               key=('k', 'm', 'phi0'),
+               unit=('kcal/mol', 'hartree', 'degree'),
+               default_unit=('hartree', 'hartree', 'radian'),
+               post_process=(None, None, None)),
+
+    PRMMapping(name='improper', columns=[4, 5, 6],
+               key_path=('input', 'force_eval', 'mm', 'forcefield', 'improper'),
+               key=('k', 'k', 'phi0'),
+               unit=('kcal/mol', 'hartree', 'degree'),
+               default_unit=('hartree', 'hartree', 'radian'),
+               post_process=(None, return_zero, None)),
+})

--- a/FOX/io/cp2k_to_prm.py
+++ b/FOX/io/cp2k_to_prm.py
@@ -1,3 +1,86 @@
+"""
+FOX.io.cp2k_to_prm
+==================
+
+A :class:`TypedMapping<FOX.typed_mapping.TypedMapping>` subclass converting CP2K settings to .prm-compatible values.
+
+Index
+-----
+.. currentmodule:: FOX.io.cp2k_to_prm
+.. autosummary::
+    PRMMapping
+    CP2K_TO_PRM
+
+API
+---
+.. autoclass:: PRMMapping
+.. autodata:: CP2K_TO_PRM
+    :annotation: : MappingProxyType[str, PRMMapping]
+
+    A :class:`Mapping<collections.abc.Mapping>` containing :class:`PRMMapping` instances.
+
+    .. code:: python
+
+        MappingProxyType({
+            'nonbonded':
+                PRMMapping(name='nbfix', columns=[2, 3],
+                           key_path=('input', 'force_eval', 'mm', 'forcefield', 'nonbonded', 'lennard-jones'),
+                           key=('epsilon', 'sigma'),
+                           unit=('kcal/mol', 'angstrom'),
+                           default_unit=('kcal/mol', 'kelvin'),
+                           post_process=(None, sigma_to_r2)),
+
+            'nonbonded14':
+                PRMMapping(name='nbfix', columns=[4, 5],
+                           key_path=('input', 'force_eval', 'mm', 'forcefield', 'nonbonded14', 'lennard-jones'),
+                           key=('epsilon', 'sigma'),
+                           unit=('kcal/mol', 'angstrom'),
+                           default_unit=('kcal/mol', 'kelvin'),
+                           post_process=(None, sigma_to_r2)),
+
+            'bonds':
+                PRMMapping(name='bonds', columns=[2, 3],
+                           key_path=('input', 'force_eval', 'mm', 'forcefield', 'bond'),
+                           key=('k', 'r0'),
+                           unit=('kcal/mol/A**2', 'angstrom'),
+                           default_unit=('internal_cp2k', 'bohr'),  # TODO: internal_cp2k ?????????
+                           post_process=(None, None)),
+
+            'angles':
+                PRMMapping(name='angles', columns=[3, 4],
+                           key_path=('input', 'force_eval', 'mm', 'forcefield', 'bend'),
+                           key=('k', 'theta0'),
+                           unit=('kcal/mol', 'degree'),
+                           default_unit=('hartree', 'radian'),
+                           post_process=(None, None)),
+
+            'urrey-bradley':
+                PRMMapping(name='angles', columns=[5, 6],
+                           key_path=('input', 'force_eval', 'mm', 'forcefield', 'bend', 'ub'),
+                           key=('k', 'r0'),
+                           unit=('kcal/mol/A**2', 'angstrom'),
+                           default_unit=('internal_cp2k', 'bohr'),  # TODO: internal_cp2k ?????????
+                           post_process=(None, None)),
+
+            'dihedrals':
+                PRMMapping(name='dihedrals', columns=[4, 5, 6],
+                           key_path=('input', 'force_eval', 'mm', 'forcefield', 'torsion'),
+                           key=('k', 'm', 'phi0'),
+                           unit=('kcal/mol', 'hartree', 'degree'),
+                           default_unit=('hartree', 'hartree', 'radian'),
+                           post_process=(None, None, None)),
+
+            'improper':
+                PRMMapping(name='improper', columns=[4, 5, 6],
+                           key_path=('input', 'force_eval', 'mm', 'forcefield', 'improper'),
+                           key=('k', 'k', 'phi0'),
+                           unit=('kcal/mol', 'hartree', 'degree'),
+                           default_unit=('hartree', 'hartree', 'radian'),
+                           post_process=(None, return_zero, None)),
+        })
+
+"""  # noqa
+
 from types import MappingProxyType
 from typing import (Optional, Iterable, Callable, FrozenSet, TypeVar, Tuple,
                     Union, Type, Any, ClassVar, Mapping)
@@ -18,7 +101,7 @@ PostProcess = Callable[[float], float]
 
 
 class PRMMapping(TypedMapping):
-    """A mapping providing tools for converting CP2K settings to .prm-compatible values.
+    """A :class:`TypedMapping<FOX.typed_mapping.TypedMapping>` providing tools for converting CP2K settings to .prm-compatible values.
 
     Parameters
     ----------
@@ -139,7 +222,6 @@ def return_zero(value: Any) -> int:
     return 0
 
 
-#: A :class:`frozenset`
 CP2K_TO_PRM: Mapping[str, PRMMappingType] = MappingProxyType({
     'nonbonded':
         PRMMapping(name='nbfix', columns=[2, 3],

--- a/FOX/io/cp2k_to_prm.py
+++ b/FOX/io/cp2k_to_prm.py
@@ -140,7 +140,7 @@ def return_zero(value: Any) -> int:
 
 
 #: A :class:`frozenset`
-CP2K_TO_PRM: Mapping[str, PRMMapping] = MappingProxyType({
+CP2K_TO_PRM: Mapping[str, PRMMappingType] = MappingProxyType({
     'nonbonded':
         PRMMapping(name='nbfix', columns=[2, 3],
                    key_path=('input', 'force_eval', 'mm', 'forcefield', 'nonbonded', 'lennard-jones'),  # noqa

--- a/FOX/io/cp2k_to_prm.py
+++ b/FOX/io/cp2k_to_prm.py
@@ -1,7 +1,14 @@
-from typing import Optional, Iterable, Callable, FrozenSet, TypeVar, Tuple, Union, Type, Any
+from types import MappingProxyType
+from typing import (Optional, Iterable, Callable, FrozenSet, TypeVar, Tuple,
+                    Union, Type, Any, ClassVar, Mapping)
 from collections import abc
 
-from ..frozen_mapping import FrozenMapping
+from ..typed_mapping import TypedMapping
+
+try:
+    from typing import TypedDict
+except ImportError:  # TypedDict was added in Python 3.8
+    TypedDict = None
 
 __all__ = ['PRMMapping', 'CP2K_TO_PRM']
 
@@ -10,49 +17,87 @@ NoneType = type(None)
 PostProcess = Callable[[float], float]
 
 
-class PRMMapping(FrozenMapping):
+class PRMMapping(TypedMapping):
     """A mapping providing tools for converting CP2K settings to .prm-compatible values.
+
+    Parameters
+    ----------
+    name : :class:`str`
+        The name of the :class:`PRMContainer<FOX.io.read_prm.PRMContainer>` attribute.
+        See :attr:`PRMMapping.name`.
+
+    columns : :class:`int` or :class:`Iterable<collections.abc.Iterable>` [:class:`int`]
+        The names relevant :class:`PRMContainer<FOX.io.read_prm.PRMContainer>`
+        DataFrame columns.
+        See :attr:`PRMMapping.columns`.
+
+    key_path : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+        The path of CP2K Settings keys leading to the property of interest.
+        See :attr:`PRMMapping.key_path`.
+
+    key : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+        The key(s) within :attr:`PRMMapping.key_path` containg the actual properties of interest,
+        *e.g.* ``"epsilon"`` and ``"sigma"``.
+        See :attr:`PRMMapping.key`.
+
+    unit : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+        The desired output unit.
+        See :attr:`PRMMapping.unit`.
+
+    default_unit : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`, optional]
+        The default unit as utilized by CP2K.
+        See :attr:`PRMMapping.default_unit`.
+
+    post_process : :class:`Callable<collections.abc.Callable>` or :class:`Iterable<collections.abc.Iterable>` [:class:`Callable<collections.abc.Callable>`]
+        Callables for post-processing the value of interest.
+        Set a particular callable to ``None`` to disable post-processing.
+        See :attr:`PRMMapping.post_process`.
 
     Attributes
     ----------
     name : :class:`str`
         The name of the :class:`PRMContainer<FOX.io.read_prm.PRMContainer>` attribute.
 
-    columns : :class:`int` or :class:`Iterable<collections.abc.Iterable>` [:class:`int`]
+    columns : :class:`tuple` [:class:`int`]
         The names relevant :class:`PRMContainer<FOX.io.read_prm.PRMContainer>`
         DataFrame columns.
 
-    key_path : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+    key_path : :class:`tuple` [:class:`str`]
         The path of CP2K Settings keys leading to the property of interest.
 
-    key : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+    key : :class:`tuple` [:class:`str`]
         The key(s) within :attr:`PRMMapping.key_path` containg the actual properties of interest,
         *e.g.* ``"epsilon"`` and ``"sigma"``.
 
-    unit : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+    unit : :class:`tuple` [:class:`str`]
         The desired output unit.
 
-    default_unit : :class:`str` or :class:`Iterable<collections.abc.Iterable>` [:class:`str`]
+    default_unit : :class:`tuple` [:class:`str`, optional]
         The default unit as utilized by CP2K.
 
-    post_process : :class:`Callable<collections.abc.Callable>` or :class:`Iterable<collections.abc.Iterable>` [:class:`Callable<collections.abc.Callable>`]
+    post_process : :class:`tuple` [:class:`Callable<collections.abc.Callable>`, optional]
         Callables for post-processing the value of interest.
         Set a particular callable to ``None`` to disable post-processing.
 
     """  # noqa
 
+    _ATTR: ClassVar[FrozenSet[str]] = frozenset({
+        'name', 'key', 'columns', 'key_path', 'unit', 'default_unit', 'post_process'
+    })
+
     def __init__(self, name: str,
+                 key: Union[str, Iterable[str]],
                  columns: Union[int, Iterable[int]],
                  key_path: Union[str, Iterable[str]],
-                 key: Union[str, Iterable[str]],
                  unit: Union[str, Iterable[str]],
                  default_unit: Union[None, str, Iterable[Optional[str]]],
                  post_process: Union[None, PostProcess, Iterable[Optional[PostProcess]]]) -> None:
+        """Initialize a :class:`PRMMapping` instance."""
         super().__init__()
         self.name = name
+        self.key = self._to_tuple(key, str)
         self.columns = self._to_tuple(columns, int)
         self.key_path = self._to_tuple(key_path, str)
-        self.key = self._to_tuple(key, str)
         self.unit = self._to_tuple(unit, str)
         self.default_unit = self._to_tuple(default_unit, (str, NoneType))
         self.post_process = self._to_tuple(post_process, (abc.Callable, NoneType))
@@ -60,6 +105,7 @@ class PRMMapping(FrozenMapping):
     @staticmethod
     def _to_tuple(value: Union[KV, Iterable[KV]],
                   def_type: Union[Type[KV], Tuple[Type[KV], ...]]) -> Tuple[KV, ...]:
+        """Convert **value** into a :class:`tuple`."""
         if isinstance(value, tuple):
             return value
         elif isinstance(value, def_type):
@@ -67,8 +113,23 @@ class PRMMapping(FrozenMapping):
         return tuple(value)
 
 
+if TypedDict is not None:
+    class _PRMMapping(TypedDict):
+        name: str
+        columns: Tuple[str, ...]
+        key_path: Tuple[str, ...]
+        key: Tuple[str, ...]
+        unit: Tuple[str, ...]
+        default_unit: Tuple[Optional[str], ...]
+        post_process: Tuple[Optional[PostProcess], ...]
+
+    PRMMappingType = Union[PRMMapping, _PRMMapping]
+else:
+    PRMMappingType = PRMMapping
+
+
 def sigma_to_r2(sigma: float) -> float:
-    r"""Convert :math:`\sigma` into :math:`|frac{1}{2} R`."""
+    r"""Convert :math:`\sigma` into :math:`\frac{1}{2} R`."""
     R = sigma * 2**(1/6)
     return R / 2
 
@@ -79,53 +140,54 @@ def return_zero(value: Any) -> int:
 
 
 #: A :class:`frozenset`
-CP2K_TO_PRM: FrozenSet[PRMMapping] = frozenset({
-    PRMMapping(name='nbfix', columns=[2, 3],
-               key_path=('input', 'force_eval', 'mm', 'forcefield', 'nonbonded', 'lennard-jones'),
-               key=('epsilon', 'sigma'),
-               unit=('kcal/mol', 'angstrom'),
-               default_unit=('kcal/mol', 'kelvin'),
-               post_process=(None, sigma_to_r2)),
-
-    PRMMapping(name='nbfix', columns=[4, 5],
-               key_path=('input', 'force_eval', 'mm', 'forcefield', 'nonbonded14', 'lennard-jones'),
-               key=('epsilon', 'sigma'),
-               unit=('kcal/mol', 'angstrom'),
-               default_unit=('kcal/mol', 'kelvin'),
-               post_process=(None, sigma_to_r2)),
-
-    PRMMapping(name='bonds', columns=[2, 3],
-               key_path=('input', 'force_eval', 'mm', 'forcefield', 'bond'),
-               key=('k', 'r0'),
-               unit=('kcal/mol/A**2', 'angstrom'),
-               default_unit=('internal_cp2k', 'bohr'),  # TODO: internal_cp2k ?????????
-               post_process=(None, None)),
-
-    PRMMapping(name='angles', columns=[3, 4],
-               key_path=('input', 'force_eval', 'mm', 'forcefield', 'bend'),
-               key=('k', 'theta0'),
-               unit=('kcal/mol', 'degree'),
-               default_unit=('hartree', 'radian'),
-               post_process=(None, None)),
-
-    PRMMapping(name='angles', columns=[5, 6],
-               key_path=('input', 'force_eval', 'mm', 'forcefield', 'bend', 'ub'),
-               key=('k', 'r0'),
-               unit=('kcal/mol/A**2', 'angstrom'),
-               default_unit=('internal_cp2k', 'bohr'),  # TODO: internal_cp2k ?????????
-               post_process=(None, None)),
-
-    PRMMapping(name='dihedrals', columns=[4, 5, 6],
-               key_path=('input', 'force_eval', 'mm', 'forcefield', 'torsion'),
-               key=('k', 'm', 'phi0'),
-               unit=('kcal/mol', 'hartree', 'degree'),
-               default_unit=('hartree', 'hartree', 'radian'),
-               post_process=(None, None, None)),
-
-    PRMMapping(name='improper', columns=[4, 5, 6],
-               key_path=('input', 'force_eval', 'mm', 'forcefield', 'improper'),
-               key=('k', 'k', 'phi0'),
-               unit=('kcal/mol', 'hartree', 'degree'),
-               default_unit=('hartree', 'hartree', 'radian'),
-               post_process=(None, return_zero, None)),
+CP2K_TO_PRM: Mapping[str, PRMMapping] = MappingProxyType({
+    'nonbonded':
+        PRMMapping(name='nbfix', columns=[2, 3],
+                   key_path=('input', 'force_eval', 'mm', 'forcefield', 'nonbonded', 'lennard-jones'),  # noqa
+                   key=('epsilon', 'sigma'),
+                   unit=('kcal/mol', 'angstrom'),
+                   default_unit=('kcal/mol', 'kelvin'),
+                   post_process=(None, sigma_to_r2)),
+    'nonbonded14':
+        PRMMapping(name='nbfix', columns=[4, 5],
+                   key_path=('input', 'force_eval', 'mm', 'forcefield', 'nonbonded14', 'lennard-jones'),  # noqa
+                   key=('epsilon', 'sigma'),
+                   unit=('kcal/mol', 'angstrom'),
+                   default_unit=('kcal/mol', 'kelvin'),
+                   post_process=(None, sigma_to_r2)),
+    'bonds':
+        PRMMapping(name='bonds', columns=[2, 3],
+                   key_path=('input', 'force_eval', 'mm', 'forcefield', 'bond'),
+                   key=('k', 'r0'),
+                   unit=('kcal/mol/A**2', 'angstrom'),
+                   default_unit=('internal_cp2k', 'bohr'),  # TODO: internal_cp2k ?????????
+                   post_process=(None, None)),
+    'angles':
+        PRMMapping(name='angles', columns=[3, 4],
+                   key_path=('input', 'force_eval', 'mm', 'forcefield', 'bend'),
+                   key=('k', 'theta0'),
+                   unit=('kcal/mol', 'degree'),
+                   default_unit=('hartree', 'radian'),
+                   post_process=(None, None)),
+    'urrey-bradley':
+        PRMMapping(name='angles', columns=[5, 6],
+                   key_path=('input', 'force_eval', 'mm', 'forcefield', 'bend', 'ub'),
+                   key=('k', 'r0'),
+                   unit=('kcal/mol/A**2', 'angstrom'),
+                   default_unit=('internal_cp2k', 'bohr'),  # TODO: internal_cp2k ?????????
+                   post_process=(None, None)),
+    'dihedrals':
+        PRMMapping(name='dihedrals', columns=[4, 5, 6],
+                   key_path=('input', 'force_eval', 'mm', 'forcefield', 'torsion'),
+                   key=('k', 'm', 'phi0'),
+                   unit=('kcal/mol', 'hartree', 'degree'),
+                   default_unit=('hartree', 'hartree', 'radian'),
+                   post_process=(None, None, None)),
+    'improper':
+        PRMMapping(name='improper', columns=[4, 5, 6],
+                   key_path=('input', 'force_eval', 'mm', 'forcefield', 'improper'),
+                   key=('k', 'k', 'phi0'),
+                   unit=('kcal/mol', 'hartree', 'degree'),
+                   default_unit=('hartree', 'hartree', 'radian'),
+                   post_process=(None, return_zero, None)),
 })

--- a/FOX/io/read_prm.py
+++ b/FOX/io/read_prm.py
@@ -11,6 +11,7 @@ Index
     PRMContainer
     PRMContainer.read
     PRMContainer.write
+    PRMContainer.overlay_mapping
     PRMContainer.overlay_cp2k_settings
 
 API
@@ -18,6 +19,7 @@ API
 .. autoclass:: PRMContainer
 .. automethod:: PRMContainer.read
 .. automethod:: PRMContainer.write
+.. automethod:: PRMContainer.overlay_mapping
 .. automethod:: PRMContainer.overlay_cp2k_settings
 
 """
@@ -34,7 +36,7 @@ import pandas as pd
 from scm.plams import Settings
 from assertionlib.dataclass import AbstractDataClass
 
-from .cp2k_to_prm import PRMMapping, PostProcess
+from .cp2k_to_prm import PRMMappingType, PostProcess
 from .cp2k_to_prm import CP2K_TO_PRM as _CP2K_TO_PRM
 from .file_container import AbstractFileContainer
 from ..functions.cp2k_utils import parse_cp2k_value
@@ -60,13 +62,17 @@ class PRMContainer(AbstractDataClass, AbstractFileContainer):
         A dictionary with Pandas print options.
         See `Options and settings <https://pandas.pydata.org/pandas-docs/stable/user_guide/options.html>`_.
 
+    CP2K_TO_PRM : :class:`Mapping<collections.abc.Mapping>` [:class:`str`, :class:`PRMMapping<FOX.io.cp2k_to_prm.PRMMapping>`]
+        A mapping providing tools for converting CP2K settings to .prm-compatible values.
+        See :data:`CP2K_TO_PRM<FOX.io.cp2k_to_prm.CP2K_TO_PRM>`.
+
     """  # noqa
 
     #: A :class:`frozenset` with the names of private instance attributes.
     #: These attributes will be excluded whenever calling :meth:`PRMContainer.as_dict`.
     _PRIVATE_ATTR: ClassVar[FrozenSet[str]] = frozenset({'_pd_printoptions'})
 
-    CP2K_TO_PRM: ClassVar[Mapping[str, PRMMapping]] = _CP2K_TO_PRM
+    CP2K_TO_PRM: ClassVar[Mapping[str, PRMMappingType]] = _CP2K_TO_PRM
 
     #: A tuple of supported .psf headers.
     HEADERS: Tuple[str, ...] = (

--- a/FOX/io/read_psf.py
+++ b/FOX/io/read_psf.py
@@ -817,19 +817,20 @@ class PSFContainer(AbstractDataClass, AbstractFileContainer):
 
         """  # noqa
         def get_res_id(at: Atom) -> int:
-            return at.properties.pdb_info.ResidueNumber or 1
+            return at.properties.get('pdb_info', {}).get('ResidueNumber', 1)
 
         def get_res_name(at: Atom) -> str:
-            return at.properties.pdb_info.ResidueName or 'COR'
+            return at.properties.get('pdb_info', {}).get('ResidueName', 'COR')
 
         def get_at_type(at: Atom) -> str:
-            return at.properties.symbol or at.symbol
+            return at.properties.get('symbol', at.symbol)
 
         def get_charge(at: Atom) -> float:
-            if at.properties.charge_float:
-                return float(at.properties.charge_float)
-            elif at.properties.charge:
-                return float(at.properties.charge)
+            properties = at.properties
+            if 'charge_float' in properties:
+                return float(properties.charge_float)
+            elif 'charge' in properties:
+                return float(properties.charge)
             return 0.0
 
         index = pd.RangeIndex(1, 1 + len(mol))

--- a/FOX/typed_mapping.py
+++ b/FOX/typed_mapping.py
@@ -1,18 +1,18 @@
 """
-FOX.classes.frozen_settings
-===========================
+FOX.typed_mapping
+=================
 
-A module which adds the :class:`.FrozenSettings` class.
+A module which adds the :class:`.TypedMapping` class.
 
 Index
 -----
-.. currentmodule:: FOX.classes.frozen_settings
+.. currentmodule:: FOX.typed_mapping
 .. autosummary::
-    FrozenSettings
+    TypedMapping
 
 API
 ---
-.. autoclass:: FOX.classes.frozen_settings.FrozenSettings
+.. autoclass:: TypedMapping
     :members:
     :private-members:
     :special-members:
@@ -26,30 +26,66 @@ from typing import (Any, Iterator, Optional, Callable, TypeVar, KeysView, ItemsV
 
 from assertionlib.dataclass import AbstractDataClass
 
-__all__ = ['FrozenMapping']
+__all__ = ['TypedMapping']
 
 KT = TypeVar('KT', bound=str)
 KV = TypeVar('KV')
 
 
-class FrozenMapping(AbstractDataClass, abc.Mapping):
-    _PRIVATE_ATTR: ClassVar[FrozenSet[str]] = frozenset({'_view'})
+class TypedMapping(AbstractDataClass, abc.Mapping):
+    """A :class:`Mapping<collections.abc.Mapping>` type which only a specific set of keys.
+
+    Attributes
+    ----------
+    _ATTR : :class:`frozenset` [:class:`str`], classvar
+        A frozenset containing all allowed keys.
+        Should be defined at the class level.
+
+    """
+
+    _PRIVATE_ATTR: ClassVar[FrozenSet[str]] = frozenset({'_view', '_PRIVATE_ATTR'})
+    _ATTR: ClassVar[FrozenSet[str]] = frozenset()
 
     def __init__(self) -> None:
-        super().__setattr__('_view', {})
+        """Initialize a :class:`TypedMapping` instance."""
+        super().__setattr__('_view', {})  # Dict[str, Any]
         super().__init__()
+
+        cls = type(self)
+        for k in cls._ATTR:
+            super().__setattr__(k, None)
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Implement :code:`setattr(self, name, value)`."""
-        if name not in self._PRIVATE_ATTR:
+        # These values should be mutable
+        if name in self._PRIVATE_ATTR:
+            super().__setattr__(name, value)
+            return
+
+        # These values can only be changed once; i.e. when they're changed from None to Any
+        elif name in self._ATTR and getattr(self, name, None) is None:
             self._view[name] = value
-        super().__setattr__(name, value)
+            super().__setattr__(name, value)
+            return
+
+        # Uhoh, trying to mutate something which should not be changed
+        cls_name = self.__class__.__name__
+        if name in self._ATTR and getattr(self, name, None) is not None:
+            raise AttributeError(f"{cls_name!r} object attribute {name!r} is read-only")
+        else:
+            raise AttributeError(f"{cls_name!r} object has no attribute {name!r}")
 
     def __delattr__(self, name: str) -> None:
         """Implement :code:`delattr(self, name)`."""
-        if name not in self._PRIVATE_ATTR:
-            del self._view[name]
-        super().__delattr__(name)
+        raise AttributeError(f"{self.__class__.__name__!r} object attribute {name!r} is read-only")
+
+    def __setitem__(self, name: str, value: Any) -> None:
+        """Implement :code:`self[name] = value`."""
+        cls = type(self)
+        if name in cls._PRIVATE_ATTR:
+            cls_name = self.__class__.__name__
+            raise AttributeError(f"{cls_name!r} object attribute {name!r} is read-only")
+        self.__setattr__(name, value)
 
     @property
     def view(self):

--- a/FOX/typed_mapping.py
+++ b/FOX/typed_mapping.py
@@ -55,6 +55,11 @@ class TypedMapping(AbstractDataClass, abc.Mapping):
         for k in cls._ATTR:
             super().__setattr__(k, None)
 
+    @property
+    def view(self):
+        """Return a read-only view of all non-private instance attributes."""
+        return MappingProxyType(self._view)
+
     def __setattr__(self, name: str, value: Any) -> None:
         """Implement :code:`setattr(self, name, value)`."""
         # These values should be mutable
@@ -87,51 +92,46 @@ class TypedMapping(AbstractDataClass, abc.Mapping):
         self.__setattr__(name, value)
 
     @property
-    def view(self):
-        """Return a read-only view of all non-private instance attributes."""
-        return MappingProxyType(self._view)
-
-    @property
     def __bool__(self) -> Callable[[], bool]:
-        """Get the :meth:`__bool__<types.MappingProxyType.__bool__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`__bool__()<types.MappingProxyType.__bool__>` method of :attr:`FrozenMapping.view`."""  # noqa
         return self.view.__bool__
 
     @property
     def __getitem__(self) -> Callable[[KT], KV]:
-        """Get the :meth:`__getitem__<types.MappingProxyType.__getitem__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`__getitem__()<types.MappingProxyType.__getitem__>` method of :attr:`FrozenMapping.view`."""  # noqa
         return self.view.__getitem__
 
     @property
     def __iter__(self) -> Callable[[], Iterator[KT]]:
-        """Get the :meth:`__iter__<types.MappingProxyType.__iter__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`__iter__()<types.MappingProxyType.__iter__>` method of :attr:`FrozenMapping.view`."""  # noqa
         return self.view.__iter__
 
     @property
     def __len__(self) -> Callable[[], int]:
-        """Get the :meth:`__len__<types.MappingProxyType.__len__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`__len__()<types.MappingProxyType.__len__>` method of :attr:`FrozenMapping.view`."""  # noqa
         return self.view.__len__
 
     @property
     def __contains__(self) -> Callable[[KT], bool]:
-        """Get the :meth:`__contains__<types.MappingProxyType.__contains__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`__contains__()<types.MappingProxyType.__contains__>` method of :attr:`FrozenMapping.view`."""  # noqa
         return self.view.__contains__
 
     @property
     def get(self) -> Callable[[KT, Optional[Any]], KV]:
-        """Get the :meth:`get<types.MappingProxyType.get>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`get()<types.MappingProxyType.get>` method of :attr:`FrozenMapping.view`."""  # noqa
         return self.view.get
 
     @property
     def keys(self) -> Callable[[], KeysView[KT]]:
-        """Get the :meth:`keys<types.MappingProxyType.keys>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`keys()<types.MappingProxyType.keys>` method of :attr:`FrozenMapping.view`."""  # noqa
         return self.view.keys
 
     @property
     def items(self) -> Callable[[], ItemsView[KT, KV]]:
-        """Get the :meth:`items<types.MappingProxyType.items>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`items()<types.MappingProxyType.items>` method of :attr:`FrozenMapping.view`."""  # noqa
         return self.view.items
 
     @property
     def values(self) -> Callable[[], ValuesView[KV]]:
-        """Get the :meth:`values<types.MappingProxyType.values>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`values()<types.MappingProxyType.values>` method of :attr:`FrozenMapping.view`."""  # noqa
         return self.view.values

--- a/FOX/typed_mapping.py
+++ b/FOX/typed_mapping.py
@@ -81,8 +81,7 @@ class TypedMapping(AbstractDataClass, abc.Mapping):
 
     def __setitem__(self, name: str, value: Any) -> None:
         """Implement :code:`self[name] = value`."""
-        cls = type(self)
-        if name in cls._PRIVATE_ATTR:
+        if name in self._PRIVATE_ATTR:
             cls_name = self.__class__.__name__
             raise AttributeError(f"{cls_name!r} object attribute {name!r} is read-only")
         self.__setattr__(name, value)

--- a/FOX/typed_mapping.py
+++ b/FOX/typed_mapping.py
@@ -2,27 +2,48 @@
 FOX.typed_mapping
 =================
 
-A module which adds the :class:`.TypedMapping` class.
+A module which adds the :class:`TypedMapping` class.
 
 Index
 -----
 .. currentmodule:: FOX.typed_mapping
 .. autosummary::
     TypedMapping
+    TypedMapping.__setattr__
+    TypedMapping.__delattr__
+    TypedMapping.__setitem__
+    TypedMapping.__bool__
+    TypedMapping.__getitem__
+    TypedMapping.__iter__
+    TypedMapping.__len__
+    TypedMapping.__contains__
+    TypedMapping.get
+    TypedMapping.keys
+    TypedMapping.items
+    TypedMapping.values
 
 API
 ---
 .. autoclass:: TypedMapping
-    :members:
-    :private-members:
-    :special-members:
+.. automethod:: TypedMapping.__setattr__
+.. automethod:: TypedMapping.__delattr__
+.. automethod:: TypedMapping.__setitem__
+.. automethod:: TypedMapping.__bool__
+.. automethod:: TypedMapping.__getitem__
+.. automethod:: TypedMapping.__iter__
+.. automethod:: TypedMapping.__len__
+.. automethod:: TypedMapping.__contains__
+.. automethod:: TypedMapping.get
+.. automethod:: TypedMapping.keys
+.. automethod:: TypedMapping.items
+.. automethod:: TypedMapping.values
 
 """
 
 from collections import abc
 from types import MappingProxyType
 from typing import (Any, Iterator, Optional, Callable, TypeVar, KeysView, ItemsView, ValuesView,
-                    ClassVar, FrozenSet)
+                    ClassVar, FrozenSet, NoReturn, Mapping)
 
 from assertionlib.dataclass import AbstractDataClass
 
@@ -33,13 +54,21 @@ KV = TypeVar('KV')
 
 
 class TypedMapping(AbstractDataClass, abc.Mapping):
-    """A :class:`Mapping<collections.abc.Mapping>` type which only a specific set of keys.
+    """A :class:`Mapping<collections.abc.Mapping>` type which only allows a specific set of keys.
+
+    Values cannot be altered after their assignment.
 
     Attributes
     ----------
+    _PRIVATE_ATTR : :class:`frozenset` [:class:`str`], classvar
+        A frozenset defining all private instance variables.
+
     _ATTR : :class:`frozenset` [:class:`str`], classvar
         A frozenset containing all allowed keys.
         Should be defined at the class level.
+
+    view : :class:`MappingProxyType<types.MappingProxyType>` [:class:`str`, :data:`Any<typing.Any>`]
+        Return a read-only view of all items specified in :attr:`TypedMapping._ATTR`.
 
     """
 
@@ -56,12 +85,19 @@ class TypedMapping(AbstractDataClass, abc.Mapping):
             super().__setattr__(k, None)
 
     @property
-    def view(self):
-        """Return a read-only view of all non-private instance attributes."""
+    def view(self) -> Mapping[KT, KV]:
+        """Return a read-only view of all items specified in :attr:`TypedMapping._ATTR`."""
         return MappingProxyType(self._view)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        """Implement :code:`setattr(self, name, value)`."""
+        """Implement :code:`setattr(self, name, value)`.
+
+        Attributes specified in :attr:`TypedMapping._PRIVATE_ATTR` can freely modified.
+        Attributes specified in :attr:`TypedMapping._ATTR` can only be modified when the
+        previous value is ``None``.
+        All other attribute cannot be modified any further.
+
+        """
         # These values should be mutable
         if name in self._PRIVATE_ATTR:
             super().__setattr__(name, value)
@@ -80,58 +116,66 @@ class TypedMapping(AbstractDataClass, abc.Mapping):
         else:
             raise AttributeError(f"{cls_name!r} object has no attribute {name!r}")
 
-    def __delattr__(self, name: str) -> None:
-        """Implement :code:`delattr(self, name)`."""
+    def __delattr__(self, name: str) -> NoReturn:
+        """Implement :code:`delattr(self, name)`.
+
+        Raises an :exc:`AttributeError`, instance variables cannot be deleted.
+
+        """
         raise AttributeError(f"{self.__class__.__name__!r} object attribute {name!r} is read-only")
 
     def __setitem__(self, name: str, value: Any) -> None:
-        """Implement :code:`self[name] = value`."""
+        """Implement :code:`self[name] = value`.
+
+        Serves as an alias for :meth:`TypedMapping.__setattr__` when **name** is in
+        :meth:`TypedMapping._ATTR`.
+
+        """
         if name in self._PRIVATE_ATTR:
-            cls_name = self.__class__.__name__
-            raise AttributeError(f"{cls_name!r} object attribute {name!r} is read-only")
+            raise KeyError(repr(name))
         self.__setattr__(name, value)
 
     @property
     def __bool__(self) -> Callable[[], bool]:
-        """Get the :meth:`__bool__()<types.MappingProxyType.__bool__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`__bool__()<types.MappingProxyType.__bool__>` method of :attr:`TypedMapping.view`."""  # noqa
         return self.view.__bool__
 
     @property
     def __getitem__(self) -> Callable[[KT], KV]:
-        """Get the :meth:`__getitem__()<types.MappingProxyType.__getitem__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`__getitem__()<types.MappingProxyType.__getitem__>` method of :attr:`TypedMapping.view`."""  # noqa
         return self.view.__getitem__
 
     @property
     def __iter__(self) -> Callable[[], Iterator[KT]]:
-        """Get the :meth:`__iter__()<types.MappingProxyType.__iter__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`__iter__()<types.MappingProxyType.__iter__>` method of :attr:`TypedMapping.view`."""  # noqa
         return self.view.__iter__
 
     @property
     def __len__(self) -> Callable[[], int]:
-        """Get the :meth:`__len__()<types.MappingProxyType.__len__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`__len__()<types.MappingProxyType.__len__>` method of :attr:`TypedMapping.view`."""  # noqa
         return self.view.__len__
 
     @property
     def __contains__(self) -> Callable[[KT], bool]:
-        """Get the :meth:`__contains__()<types.MappingProxyType.__contains__>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`__contains__()<types.MappingProxyType.__contains__>` method of :attr:`TypedMapping.view`."""  # noqa
         return self.view.__contains__
 
     @property
     def get(self) -> Callable[[KT, Optional[Any]], KV]:
-        """Get the :meth:`get()<types.MappingProxyType.get>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`get()<types.MappingProxyType.get>` method of :attr:`TypedMapping.view`."""  # noqa
         return self.view.get
 
     @property
     def keys(self) -> Callable[[], KeysView[KT]]:
-        """Get the :meth:`keys()<types.MappingProxyType.keys>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`keys()<types.MappingProxyType.keys>` method of :attr:`TypedMapping.view`."""  # noqa
         return self.view.keys
 
     @property
     def items(self) -> Callable[[], ItemsView[KT, KV]]:
-        """Get the :meth:`items()<types.MappingProxyType.items>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`items()<types.MappingProxyType.items>` method of :attr:`TypedMapping.view`."""  # noqa
         return self.view.items
 
     @property
     def values(self) -> Callable[[], ValuesView[KV]]:
-        """Get the :meth:`values()<types.MappingProxyType.values>` method of :attr:`FrozenMapping.view`."""  # noqa
+        """Get the :meth:`values()<types.MappingProxyType.values>` method of :attr:`TypedMapping.view`."""  # noqa
         return self.view.values

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@
 
 
 #################################################
-Automated Forcefield Optimization Extension 0.7.3
+Automated Forcefield Optimization Extension 0.7.4
 #################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and

--- a/docs/0_documentation.rst
+++ b/docs/0_documentation.rst
@@ -16,3 +16,6 @@ Auto-FOX Documentation
     :hidden:
 
     _0_file_container
+    _1_read_prm
+    _2_cp2k_to_prm
+    _3_typed_mapping

--- a/docs/_2_cp2k_to_prm.rst
+++ b/docs/_2_cp2k_to_prm.rst
@@ -1,0 +1,4 @@
+cp2k_to_prm
+===========
+
+.. automodule:: FOX.io.cp2k_to_prm

--- a/docs/_3_typed_mapping.rst
+++ b/docs/_3_typed_mapping.rst
@@ -1,0 +1,4 @@
+typed_mapping
+=============
+
+.. automodule:: FOX.typed_mapping

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ copyright = f'{year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.7.3'  # The full version, including alpha/beta/rc tags.
+release = '0.7.4'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'scipy',
         'pandas',
         'schema',
-        'AssertionLib>=2.0',
+        'AssertionLib>=2.1',
         'plams@git+https://github.com/SCM-NV/PLAMS@master'
     ],
     setup_requires=[


### PR DESCRIPTION
* Increased the [AssertionLib](https://github.com/nlesc-nano/AssertionLib) version requirement to >= v2.1.
* Generalized ``PRMContainer.overlay_cp2k_settings()`` to work for all
  forcefield parameters (potentially) specified in CP2K settings.
* Added the ``PRMContainer.overlay_mapping()`` function for overlaying
  an arbitrary (nested) Mapping with the ``PSFContainer``.
* Added the ``TypedMapping`` class, a baseclass for creating typed ``Mappings``,
  *i.e.* Mappings with a set number of specific keys.
* Exchange a number of ``Settings.__contains__()`` operations for ``Settings.get()``.