### PR TITLE
Treat an ARMC iteration as failed if a Cp2kJob crashed/failed prematurely

### DIFF
--- a/FOX/classes/monte_carlo.py
+++ b/FOX/classes/monte_carlo.py
@@ -435,6 +435,8 @@ class MonteCarlo(AbstractDataClass, abc.Mapping):
             job.name += '.opt'
             self.job_cache.append(job)
             results = job.run()
+            if job.status in {'crashed', 'failed'}:
+                return None
             try:  # Construct and return a MultiMolecule object
                 path = results.get_xyz_path()
                 mol = MultiMolecule.from_xyz(path)
@@ -476,6 +478,8 @@ class MonteCarlo(AbstractDataClass, abc.Mapping):
             job.name += '.MD'
             self.job_cache.append(job)
             results = job.run()
+            if job.status in {'crashed', 'failed'}:
+                return None
             try:  # Construct and return a MultiMolecule object
                 path = results.get_xyz_path()
                 mol = MultiMolecule.from_xyz(path)


### PR DESCRIPTION
* Previously a Job's results would still be used (if available) when a job crashed prematurely.
This has now been changed.