### PR TITLE
Log the optimum ARMC cycle in get_best() and overlay_descriptor()

### DIFF
--- a/FOX/logger.py
+++ b/FOX/logger.py
@@ -19,7 +19,7 @@ API
 import logging
 from typing import Optional, Type, Any, Callable
 
-__all__ = ['get_logger', 'Plams2Logger']
+__all__ = ['get_logger', 'Plams2Logger', 'DEFAULT_LOGGER']
 
 
 def get_logger(name: str,
@@ -163,3 +163,7 @@ class Plams2Logger:
     def flush(self) -> None:
         """Dummy method for ensuring this instances' compatibility as a pseudo-filelike object."""
         return None
+
+
+#: The default Auto-FOX :class:`~logging.Logger`.
+DEFAULT_LOGGER = get_logger('FOX', handler_type=logging.StreamHandler)


### PR DESCRIPTION
* Log the optimum ARMC cycle in the [``get_best()``](https://auto-fox.readthedocs.io/en/latest/7_recipes.html#FOX.recipes.param.get_best) and [``overlay_descriptor()``](https://auto-fox.readthedocs.io/en/latest/7_recipes.html#FOX.recipes.param.overlay_descriptor) recipes.