### PR TITLE
Auto-FOX 0.8.7

### DIFF
--- a/FOX/armc/sanitization.py
+++ b/FOX/armc/sanitization.py
@@ -221,6 +221,7 @@ def get_param(dct: ParamMapping_) -> Tuple[ParamMapping, dict, dict]:
     _sub_prm_dict = split_dict(
         _prm_dict, preserve_order=True, keep_keys={'type', 'move_range', 'func', 'kwargs'}
     )
+    _sub_prm_dict_frozen = _get_prm_frozen(_sub_prm_dict)
 
     prm_dict = validate_param(_prm_dict)
     kwargs = prm_dict.pop('kwargs')
@@ -228,7 +229,10 @@ def get_param(dct: ParamMapping_) -> Tuple[ParamMapping, dict, dict]:
     constraints, min_max = _get_prm_constraints(_sub_prm_dict)
     data[['min', 'max']] = min_max
 
-    _sub_prm_dict_frozen = _get_prm_frozen(_sub_prm_dict)
+    for *_key, value in _get_prm(_sub_prm_dict_frozen):
+        key = tuple(_key)
+        data.loc[key, :] = [value, True, -np.inf, np.inf]
+    data.sort_index(inplace=True)
 
     param_type = prm_dict.pop('type')  # type: ignore
     return (
@@ -407,6 +411,7 @@ def _get_param_df(dct: Mapping[str, Any]) -> pd.DataFrame:
     df = pd.DataFrame(data, columns=columns)
     df.set_index(['key', 'param_type', 'atoms'], inplace=True)
 
+    df['constant'] = False
     df['min'] = -np.inf
     df['max'] = np.inf
     return df

--- a/FOX/armc/sanitization.py
+++ b/FOX/armc/sanitization.py
@@ -148,12 +148,8 @@ def _guess_param(mc: MonteCarloABC, prm: dict,
     # Update the variable parameters
     param_mapping = mc.param
     for k, v in seq:
-        param = v['param']
-        for atom, value in v.items():
-            if atom == 'param':
-                continue
-            key = (k, param, atom)
-
+        iterator = (((k, v['param'], at), value) for at, value in v.items() if at == 'param')
+        for key, value in iterator:
             param_mapping['param'].loc[key] = value
             param_mapping['param_old'].loc[key] = value
             param_mapping['min'][key] = -np.inf

--- a/FOX/armc/sanitization.py
+++ b/FOX/armc/sanitization.py
@@ -16,7 +16,7 @@ import os
 import copy
 from pathlib import Path
 from itertools import islice
-from collections import abc
+from collections import abc, Counter
 from typing import (
     Union, Iterable, Tuple, Optional, Mapping, Any, MutableMapping, Hashable,
     Dict, TYPE_CHECKING, Generator, List, Collection, TypeVar, overload, cast
@@ -100,6 +100,7 @@ def dict_to_armc(input_dict: MainMapping) -> Tuple[MonteCarloABC, RunDict]:
     psf_list: Optional[List[PSFContainer]] = get_psf(dct['psf'], mol_list)
     run_kwargs['psf'] = psf_list
     update_count(param, psf=psf_list, mol=mol_list)
+    _parse_ligand_alias(psf_list, prm=param)
     if psf_list is not None:
         mc.pes_post_process = [AtomsFromPSF.from_psf(*psf_list)]
         workdir = Path(run_kwargs['path']) / run_kwargs['folder']
@@ -224,12 +225,17 @@ def get_param(dct: ParamMapping_) -> Tuple[ParamMapping, dict, dict]:
     prm_dict = validate_param(_prm_dict)
     kwargs = prm_dict.pop('kwargs')
     data = _get_param_df(_sub_prm_dict)
-    data[['constraints', 'min', 'max']] = list(_get_prm_constraints(_sub_prm_dict))
+    constraints, min_max = _get_prm_constraints(_sub_prm_dict)
+    data[['min', 'max']] = min_max
 
     _sub_prm_dict_frozen = _get_prm_frozen(_sub_prm_dict)
 
     param_type = prm_dict.pop('type')  # type: ignore
-    return param_type(data, **prm_dict, **kwargs), _sub_prm_dict, _sub_prm_dict_frozen
+    return (
+        param_type(data, constraints=constraints, **prm_dict, **kwargs),
+        _sub_prm_dict,
+        _sub_prm_dict_frozen,
+    )
 
 
 def get_pes(dct: Mapping[str, PESMapping]) -> Dict[str, PESDict]:
@@ -351,7 +357,7 @@ def _psf_idx_iterator(job_list: Iterable[T], phi: Iterable) -> Generator[Tuple[i
             yield i, job
 
 
-def _update_psf_settings(job_lists: Iterable[Iterable[dict]], phi: Iterable,
+def _update_psf_settings(job_lists: Iterable[Iterable[MutableMapping[str, Any]]], phi: Iterable,
                          workdir: Union[str, os.PathLike]) -> None:
     """Set the .psf path in all job settings."""
     for job_list in job_lists:
@@ -401,7 +407,6 @@ def _get_param_df(dct: Mapping[str, Any]) -> pd.DataFrame:
     df = pd.DataFrame(data, columns=columns)
     df.set_index(['key', 'param_type', 'atoms'], inplace=True)
 
-    df['constraints'] = None
     df['min'] = -np.inf
     df['max'] = np.inf
     return df
@@ -460,8 +465,12 @@ def _get_prm_frozen(dct: Mapping[str, Union[MutableMapping, Iterable[MutableMapp
     return ret if ret else None
 
 
-def _get_prm_constraints(dct: Mapping[str, Union[MutableMapping, Iterable[MutableMapping]]]
-                         ) -> Generator[Tuple[Optional[dict], float, float], None, None]:
+def _get_prm_constraints(
+    dct: Mapping[str, Union[MutableMapping, Iterable[MutableMapping]]]
+) -> Tuple[
+    Dict[Tuple[str, str], Optional[List[Dict[str, float]]]],
+    List[Tuple[float, float]]
+]:
     """Parse all user-provided constraints.
 
     Yields
@@ -476,6 +485,9 @@ def _get_prm_constraints(dct: Mapping[str, Union[MutableMapping, Iterable[Mutabl
     """
     ignore_keys = {'frozen', 'constraints', 'param', 'unit', 'guess'}
 
+    constraints_dict: Dict[Tuple[str, str], Optional[List[Dict[str, float]]]] = {}
+    min_max: List[Tuple[float, float]] = []
+
     dct_iterator = prm_iter(dct)
     for key_alias, sub_dict in dct_iterator:
         try:
@@ -483,15 +495,45 @@ def _get_prm_constraints(dct: Mapping[str, Union[MutableMapping, Iterable[Mutabl
         except KeyError:
             for k in sub_dict:
                 if k not in ignore_keys:
-                    yield None, -np.inf, np.inf
+                    min_max.append((-np.inf, np.inf))
+            constraints_dict[key_alias, sub_dict["param"]] = []
             continue
 
         extremites, constraints = assign_constraints(proto_constraints)
         for k in sub_dict:
             if k not in ignore_keys:
-                yield (constraints,
-                       extremites.get((k, 'min'), -np.inf),
-                       extremites.get((k, 'max'), np.inf))
+                min_max.append((
+                    extremites.get((k, 'min'), -np.inf),
+                    extremites.get((k, 'max'), np.inf)
+                ))
+        constraints_dict[key_alias, sub_dict["param"]] = (
+            constraints if constraints is not None else []
+        )
+    return constraints_dict, min_max
+
+
+def _parse_ligand_alias(psf_list: Optional[List[PSFContainer]], prm: ParamMapping) -> None:
+    """Replace ``$LIGAND`` constraints with explicit ligands."""
+    not_implemented = psf_list is None or len(psf_list) != 1
+    if not not_implemented:
+        psf: PSFContainer = psf_list[0]
+        lig_id = psf.residue_id.iloc[-1]
+        atom_types: Iterable[str] = psf.atom_type[psf.residue_id == lig_id].values
+        atom_counter = Counter(atom_types)
+
+    for lst in prm.constraints.values():
+        for series in lst:
+            if "$LIGAND" not in series:
+                continue
+            elif not_implemented:
+                raise NotImplementedError
+
+            i = series.pop("$LIGAND")
+            for k, v in atom_counter.items():
+                if k in series:
+                    series[k] += v * i
+                else:
+                    series[k] = v * i
 
 
 @overload

--- a/FOX/armc/sanitization.py
+++ b/FOX/armc/sanitization.py
@@ -42,7 +42,7 @@ from ..io.read_psf import PSFContainer, overlay_str_file, overlay_rtf_file
 from ..classes import MultiMolecule
 from ..functions.cp2k_utils import UNIT_MAP
 from ..functions.molecule_utils import fix_bond_orders, residue_argsort
-from ..functions.charge_utils import assign_constraints
+from ..functions.charge_parser import assign_constraints
 
 if TYPE_CHECKING:
     from .package_manager import PackageManager, PkgDict

--- a/FOX/functions/charge_parser.py
+++ b/FOX/functions/charge_parser.py
@@ -1,0 +1,146 @@
+"""A module with functions related to the parsing of parameter constraints.
+
+Index
+-----
+.. currentmodule:: FOX.functions.charge_parser
+.. autosummary::
+    assign_constraints
+
+API
+---
+.. autofunction:: assign_constraints
+
+"""
+
+from types import MappingProxyType
+from typing import Optional, Dict, Union, Iterable, Tuple,  Generator, overload, List
+
+__all__ = ["assign_constraints"]
+
+ExtremiteDict = Dict[Tuple[str, str], float]
+ConstrainList = List[Dict[str, float]]
+
+#: Map ``"min"`` to ``"max"`` and *vice versa*.
+_INVERT = MappingProxyType({
+    'max': 'min',
+    'min': 'max'
+})
+
+#: Map :math:`>`, :math:`<`, :math:`\ge` and :math:`\le` to either ``"min"`` or ``"max"``.
+_OPPERATOR_MAPPING = MappingProxyType({
+    '<': 'min',
+    '<=': 'min',
+    '>': 'max',
+    '>=': 'max'
+})
+
+
+def assign_constraints(constraints: Union[str, Iterable[str]]
+                       ) -> Tuple[ExtremiteDict, Optional[ConstrainList]]:
+    operator_set = {'>', '<', '*', '==', '+', '-'}
+
+    # Parse integers and floats
+    if isinstance(constraints, str):
+        constraints = [constraints]
+
+    constrain_list = []
+    for item in constraints:
+        for i in operator_set:  # Sanitize all operators; ensure they are surrounded by spaces
+            item = item.replace(i, f'~{i}~')
+
+        item_list = [i.strip().rstrip() for i in item.split('~')]
+        if len(item_list) == 1:
+            continue
+
+        for i, j in enumerate(item_list):  # Convert strings to floats where possible
+            try:
+                float_j = float(j)
+            except ValueError:
+                pass
+            else:
+                item_list[i] = float_j
+
+        constrain_list.append(item_list)
+
+    # Set values in **param**
+    extremite_dict: ExtremiteDict = {}
+    constraints_ = None
+    for constrain in constrain_list:
+        if '==' in constrain:
+            constraints_ = _eq_constraints(constrain)
+        else:
+            extremite_dict.update(_gt_lt_constraints(constrain))
+    return extremite_dict, constraints_
+
+
+def _gt_lt_constraints(constrain: List[str]
+                       ) -> Generator[Tuple[Tuple[str, str], float], None, None]:
+    r"""Parse :math:`>`, :math:`<`, :math:`\ge` and :math:`\le`-type constraints."""
+    for i, j in enumerate(constrain):
+        if j not in _OPPERATOR_MAPPING:
+            continue
+
+        operator, value, atom = _OPPERATOR_MAPPING[j], constrain[i-1], constrain[i+1]
+        if isinstance(atom, float):
+            atom, value = value, atom
+            operator = _INVERT[operator]
+        yield (atom, operator), value
+
+
+@overload
+def _find_float(iterable: Tuple[str]) -> Tuple[str, float]: ...
+@overload
+def _find_float(iterable: Tuple[str, str]) -> Tuple[str, float]: ...
+def _find_float(iterable):  # noqa: E302
+    """Take an iterable of 2 strings and identify which element can be converted into a float."""
+    try:
+        i, j = iterable
+    except ValueError:
+        return iterable[0], 1.0
+
+    if i == "-":
+        return j, -1.0
+    elif j == "-":
+        return i, -1.0
+
+    try:
+        return j, float(i)
+    except ValueError:
+        return i, float(j)
+
+
+def _eq_constraints(constrain_: List[str]) -> ConstrainList:
+    """Parse :math:`a = i * b`-type constraints."""
+    constrain = ''.join(str(i) for i in constrain_).split('==')
+    # import pdb; pdb.set_trace()
+
+    # Assign all other constraints
+    ret = []
+    for _item in constrain:
+        dct: Dict[str, float] = {}
+        item_split = _split_operator(_item)
+        for item in item_split:
+            item_list = item.split('*')
+            atom, i = _find_float(item_list)
+            dct[atom] = i
+
+        ret.append(dct)
+    return ret
+
+
+def _split_operator(constrain: str) -> List[str]:
+    plus_split = constrain.split("+")
+    if '-' not in constrain:
+        return plus_split
+
+    ret = []
+    for item in plus_split:
+        if '-' not in item:
+            ret.append(item)
+            continue
+
+        item_split = item.split("-")
+        if item_split[0]:
+            ret.append(item_split[0])
+        ret += [f'-{i}' for i in item_split[1:]]
+    return ret

--- a/FOX/functions/charge_parser.py
+++ b/FOX/functions/charge_parser.py
@@ -118,6 +118,9 @@ def _eq_constraints(constrain_: List[str]) -> ConstrainList:
     ret = []
     for _item in constrain:
         dct: Dict[str, float] = {}
+        if ")" in _item or "(" in _item:
+            raise NotImplementedError(f"Parenthesized constraints are not supported: {_item!r}")
+
         item_split = _split_operator(_item)
         for item in item_split:
             item_list = item.split('*')

--- a/FOX/functions/charge_utils.py
+++ b/FOX/functions/charge_utils.py
@@ -182,12 +182,12 @@ def constrained_update(atom: KT, value: float, param: pd.Series, count: pd.Serie
         if atom in ref_coef.index:
             break
     else:
-        raise ValueError(repr(atom))
+        return None
     idx = ref_coef.index
     idx_ref = idx.tolist()
     net_charge: float = (param.loc[idx] * ref_coef.loc[idx]).sum()
 
-    df = pd.DataFrame({'param': param, 'count': count,
+    df = pd.DataFrame({'param': param, 'count': 0,
                        'prm_min': param_min, 'prm_max': param_max})
 
     # Update the charge of all other charge-constraint blocks

--- a/tests/test_charge_parser.py
+++ b/tests/test_charge_parser.py
@@ -1,0 +1,42 @@
+"""A module for testing :mod:`FOX.functions.charge_parser` ."""
+
+from assertionlib import assertion
+
+from FOX.functions.charge_parser import assign_constraints
+
+
+def test_assign_constraints() -> None:
+    """Test :func:`assign_constraints`."""
+    constraints = [
+        'H < 1',
+        'C >2.0',
+        '3.0> N',
+        '4<O',
+        '1 < F< 2.0',
+        '2 > P >1.0',
+        'S == 2 * Cl == 0.5*Br + -1.5*K - 1*Na == 1* I',
+        '1 < H H < 2',
+    ]
+    extremite, constrain_list = assign_constraints(constraints)
+
+    extremite_ref = {
+        ('H', 'max'): 1.0,
+        ('C', 'min'): 2.0,
+        ('N', 'max'): 3.0,
+        ('O', 'min'): 4.0,
+        ('F', 'min'): 1.0,
+        ('F', 'max'): 2.0,
+        ('P', 'max'): 2.0,
+        ('P', 'min'): 1.0,
+        ('H H', 'min'): 1.0,
+        ('H H', 'max'): 2.0
+    }
+    assertion.eq(extremite, extremite_ref)
+
+    constrain_ref = [
+        {"S": 1.0},
+        {"Cl": 2.0},
+        {"Br": 0.5, "K": -1.5, "Na": -1.0},
+        {"I": 1.0}
+    ]
+    assertion.eq(constrain_list, constrain_ref)

--- a/tests/test_charge_utils.py
+++ b/tests/test_charge_utils.py
@@ -1,15 +1,10 @@
 """A module for testing :mod:`FOX.functions.charge_utils` ."""
 
-import functools
-from pathlib import Path
-
 import numpy as np
 import pandas as pd
 from assertionlib import assertion
 
-from FOX.functions.charge_utils import assign_constraints, update_charge
-
-PATH = Path('tests') / 'test_files'
+from FOX.functions.charge_utils import update_charge
 
 PARAM = pd.Series({
     'Cd': 0.9768,
@@ -26,50 +21,6 @@ ATOM_COEFS = (
     pd.Series({'Cd': 1}),
     pd.Series({"O": -4, "C": -2, "H": -2})
 )
-
-
-def test_assign_constraints() -> None:
-    """Test :func:`assign_constraints`."""
-    constraints = [
-        'H < 1',
-        'C >2.0',
-        '3.0> N',
-        '4<O',
-        '1 < F< 2.0',
-        '2 > P >1.0',
-        'S == 2 * Cl == 0.5*Br == 1* I',
-        '1 < H H < 2'
-    ]
-
-    partial: dict
-    extremite, partial = assign_constraints(constraints)  # type: ignore
-
-    extremite_ref = {
-        ('H', 'max'): 1.0,
-        ('C', 'min'): 2.0,
-        ('N', 'max'): 3.0,
-        ('O', 'min'): 4.0,
-        ('F', 'min'): 1.0,
-        ('F', 'max'): 2.0,
-        ('P', 'max'): 2.0,
-        ('P', 'min'): 1.0,
-        ('H H', 'min'): 1.0,
-        ('H H', 'max'): 2.0
-    }
-    assertion.eq(extremite, extremite_ref)
-
-    partial_ref = {'S': functools.partial(np.multiply, 1.0),
-                   'Cl': functools.partial(np.multiply, 2.0),
-                   'Br': functools.partial(np.multiply, 0.5),
-                   'I': functools.partial(np.multiply, 1.0)}
-
-    assertion.eq(partial.keys(), partial_ref.keys())
-    iterator = ((v, partial_ref[k]) for k, v in partial.items())
-    for v1, v2 in iterator:
-        assertion.isinstance(v1, functools.partial)
-        assertion.is_(v1.func, v2.func)
-        assertion.eq(v1.args, v2.args)
-        assertion.eq(v1.keywords, v2.keywords)
 
 
 def _validate(atom: str, value: float, param: pd.Series) -> None:

--- a/tests/test_charge_utils.py
+++ b/tests/test_charge_utils.py
@@ -4,11 +4,28 @@ import functools
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 from assertionlib import assertion
 
-from FOX.functions.charge_utils import assign_constraints
+from FOX.functions.charge_utils import assign_constraints, update_charge
 
 PATH = Path('tests') / 'test_files'
+
+PARAM = pd.Series({
+    'Cd': 0.9768,
+    'Se': -0.9768,
+    'O': -0.47041,
+    'C': 0.4524,
+    'H': 0.0
+})
+COUNT = pd.Series({'Cd': 68, 'Se': 55, 'C': 26, 'H': 26, 'O': 52})
+PRM_MIN = pd.Series({"Cd": 0, "Se": -2, "O": -1, "C": -np.inf, "H": -np.inf})
+PRM_MAX = pd.Series({"Cd": 2, "Se": 0, "O": 0, "C": np.inf, "H": np.inf})
+EXCLUDE = {"H"}
+ATOM_COEFS = (
+    pd.Series({'Cd': 1}),
+    pd.Series({"O": -4, "C": -2, "H": -2})
+)
 
 
 def test_assign_constraints() -> None:
@@ -53,3 +70,45 @@ def test_assign_constraints() -> None:
         assertion.is_(v1.func, v2.func)
         assertion.eq(v1.args, v2.args)
         assertion.eq(v1.keywords, v2.keywords)
+
+
+def _validate(atom: str, value: float, param: pd.Series) -> None:
+    """Validate the moves of :func:`test_constraint_blocks`."""
+    ident = f"{atom}={value}"
+    assertion.isclose(param[atom], value, abs_tol=0.001, message=f'{atom} ({ident})')
+    for min_, max_, (key, v) in zip(PRM_MIN, PRM_MAX, param.items()):
+        assertion.le(min_, v, message=f'{key} ({ident})')
+        assertion.ge(max_, v, message=f'{key} ({ident})')
+
+    assertion.isclose((param * COUNT).sum(), 0, abs_tol=0.001, message=f"net charge ({ident})")
+    for key in EXCLUDE:
+        assertion.eq(param[key], PARAM[key], message=f'{key} ({ident})')
+
+    idx1 = ATOM_COEFS[0].index
+    idx2 = ATOM_COEFS[1].index
+    v1 = (param[idx1] * ATOM_COEFS[0]).sum()
+    v2 = (param[idx2] * ATOM_COEFS[1]).sum()
+    assertion.isclose(v1, v2, abs_tol=0.001, message=f"{idx1} and {idx2} ({ident})")
+
+
+def test_constraint_blocks() -> None:
+    """Test updates for the following constraints: :math:`Cd = -2 * (2*O + C + H)`."""
+    atoms = ("Cd", "Se", "C", "O")
+    values = np.arange(0.5, 1.55, 0.05)
+    iterator = ((at, PARAM[at] * i) for at in atoms for i in values)
+
+    param = PARAM.copy()
+    for atom, value in iterator:
+        ex = update_charge(
+            atom, value,
+            param=param,
+            count=COUNT,
+            atom_coefs=ATOM_COEFS,
+            prm_min=PRM_MIN,
+            prm_max=PRM_MAX,
+            exclude=EXCLUDE,
+            net_charge=0,
+        )
+        if ex is not None:
+            raise ex
+        _validate(atom, value, param)

--- a/tests/test_files/armc.yaml
+++ b/tests/test_files/armc.yaml
@@ -9,7 +9,12 @@ param:
 
     charge:
         param: charge
-        constraints: [0.5 < Cd < 1.5, -0.5 > Se > -1.5, 0 > OG2D2 > -1]
+        constraints: [
+            Cd == -2 * $LIGAND,
+            0.5 < Cd < 1.5,
+            -0.5 > Se > -1.5,
+            0 > OG2D2 > -1
+        ]
         Cd: 0.9768
         Se: -0.9768
         OG2D2: -0.4704

--- a/tests/test_files/armc.yaml
+++ b/tests/test_files/armc.yaml
@@ -18,7 +18,8 @@ param:
         Cd: 0.9768
         Se: -0.9768
         OG2D2: -0.4704
-        CG2O3: 0.4524
+        frozen:
+            CG2O3: 0.4524
     lennard_jones:
         -   unit: kjmol
             param: epsilon

--- a/tests/test_hdf5_utils.py
+++ b/tests/test_hdf5_utils.py
@@ -29,9 +29,9 @@ def test_create_hdf5():
     ref_dict.acceptance.dtype = bool
     ref_dict.aux_error.shape = 500, 100, 1, 1
     ref_dict.aux_error.dtype = np.float
-    ref_dict.aux_error_mod.shape = 500, 100, 1, 15
+    ref_dict.aux_error_mod.shape = 500, 100, 1, 16
     ref_dict.aux_error_mod.dtype = np.float
-    ref_dict.param.shape = 500, 100, 1, 14
+    ref_dict.param.shape = 500, 100, 1, 15
     ref_dict.param.dtype = np.float
     ref_dict.phi.shape = 500, 1
     ref_dict.phi.dtype = np.float
@@ -44,8 +44,8 @@ def test_create_hdf5():
         create_hdf5(hdf5_file, armc)
         with h5py.File(hdf5_file, 'r') as f:
             for key, value in f.items():
-                assertion.shape_eq(value, ref_dict[key].shape)
-                assertion.isinstance(value[:].item(0), ref_dict[key].dtype)
+                assertion.shape_eq(value, ref_dict[key].shape, message=key)
+                assertion.isinstance(value[:].item(0), ref_dict[key].dtype, message=key)
     finally:
         remove(hdf5_file) if isfile(hdf5_file) else None
 
@@ -62,7 +62,7 @@ def test_to_hdf5():
     hdf5_dict = {
         'xyz': [FOX.MultiMolecule.from_xyz(FOX.example_xyz)],
         'phi': np.array([5.0]),
-        'param': np.array(np.arange(14, dtype=float), ndmin=2),
+        'param': np.array(np.arange(15, dtype=float), ndmin=2),
         'acceptance': True,
         'aux_error': np.array([2.0]),
     }

--- a/tests/test_param_mapping.py
+++ b/tests/test_param_mapping.py
@@ -10,19 +10,27 @@ from FOX.testing_utils import validate_mapping
 _DATA = {
     ('charge', 'charge', 'Cd'): 0.9768,
     ('charge', 'charge', 'Se'): -0.9768,
-    ('charge', 'charge', 'O_1'): -0.4704,
-    ('charge', 'charge', 'C_1'): 0.4524,
+    ('charge', 'charge', 'O'): -0.4704,
+    ('charge', 'charge', 'C'): 0.4524,
+    ('charge', 'charge', 'H'): 0.0,
     ('lj', 'sigma', 'Cd'): 0.9768,
     ('lj', 'sigma', 'Se'): -0.9768,
-    ('lj', 'sigma', 'O_1'): -0.4704,
-    ('lj', 'sigma', 'C_1'): 0.4524
+    ('lj', 'sigma', 'O'): -0.4704,
+    ('lj', 'sigma', 'C'): 0.4524,
+    ('lj', 'sigma', 'H'): 0.0,
 }
-_DF = pd.DataFrame({'param': _DATA})
-_DF['count'] = 2 * [68, 55, 52, 26]
-_DF['min'] = _DF['param'] - 0.5
-_DF['max'] = _DF['param'] + 0.5
 
-PARAM = ParamMapping(_DF)
+_DF = pd.DataFrame({'param': _DATA})
+_DF['count'] = 2 * [68, 55, 52, 26, 26]
+_DF['min'] = _DF['param'] - 0.5 * abs(_DF['param'])
+_DF['max'] = _DF['param'] + 0.5 * abs(_DF['param'])
+_DF['constant'] = 2 * [False, False, False, False, True]
+
+_CONSTRAINTS = {
+    ('charge', 'charge'): [{'Cd': 1.0}, {'O': -4.0, 'C': -2.0, 'H': -2.0}]
+}
+
+PARAM = ParamMapping(_DF, constraints=_CONSTRAINTS)
 
 
 def test_mapping():
@@ -48,11 +56,13 @@ def test_call():
         try:
             assert (param['param'][0] <= param['max']).all()
         except AssertionError as ex:
-            msg = f"iteration{i}\n{pd.DataFrame({'param': param['param'], 'max': param['max']})}"
-            raise AssertionError(msg).with_traceback(ex.__tarceback__)
+            df = pd.DataFrame({'param': param['param'][0], 'max': param['max']})
+            msg = f"iteration{i}\n{df.round(2)}"
+            raise AssertionError(msg) from ex
 
         try:
             assert (param['param'][0] >= param['min']).all()
         except AssertionError as ex:
-            msg = f"iteration{i}\n{pd.DataFrame({'param': param['param'], 'min': param['min']})}"
-            raise AssertionError(msg).with_traceback(ex.__tarceback__)
+            df = pd.DataFrame({'param': param['param'][0], 'max': param['min']})
+            msg = f"iteration{i}\n{df.round(2)}"
+            raise AssertionError(msg) from ex

--- a/tests/test_param_mapping.py
+++ b/tests/test_param_mapping.py
@@ -8,23 +8,23 @@ from FOX.armc import ParamMapping
 from FOX.testing_utils import validate_mapping
 
 _DATA = {
-    ('charge', 'charge', 'Cd'): 0.9768,
-    ('charge', 'charge', 'Se'): -0.9768,
-    ('charge', 'charge', 'O'): -0.4704,
     ('charge', 'charge', 'C'): 0.4524,
+    ('charge', 'charge', 'Cd'): 0.9768,
     ('charge', 'charge', 'H'): 0.0,
-    ('lj', 'sigma', 'Cd'): 0.9768,
-    ('lj', 'sigma', 'Se'): -0.9768,
-    ('lj', 'sigma', 'O'): -0.4704,
+    ('charge', 'charge', 'O'): -0.4704,
+    ('charge', 'charge', 'Se'): -0.9768,
     ('lj', 'sigma', 'C'): 0.4524,
+    ('lj', 'sigma', 'Cd'): 0.9768,
     ('lj', 'sigma', 'H'): 0.0,
+    ('lj', 'sigma', 'O'): -0.4704,
+    ('lj', 'sigma', 'Se'): -0.9768,
 }
 
 _DF = pd.DataFrame({'param': _DATA})
-_DF['count'] = 2 * [68, 55, 52, 26, 26]
+_DF['count'] = 2 * [26, 68, 26, 52, 55]
 _DF['min'] = _DF['param'] - 0.5 * abs(_DF['param'])
 _DF['max'] = _DF['param'] + 0.5 * abs(_DF['param'])
-_DF['constant'] = 2 * [False, False, False, False, True]
+_DF['constant'] = 2 * [False, False, True, False, False]
 
 _CONSTRAINTS = {
     ('charge', 'charge'): [{'Cd': 1.0}, {'O': -4.0, 'C': -2.0, 'H': -2.0}]
@@ -43,12 +43,12 @@ def test_call():
     param = PARAM.copy(deep=True)
     ref = sum(param['param'][0].loc['charge'] * param['count'].loc['charge'])
 
+    failed_iterations = []
     for i in range(1000):
         ex = param()
         if isinstance(ex, Exception):
-            warning = RuntimeWarning(f"\niteration {i}: {ex}")
-            warning.__cause__ = ex
-            warnings.warn(warning)
+            failed_iterations.append(i)
+            ex_backup = ex
 
         value = sum(param['param'][0].loc['charge'] * param['count'].loc['charge'])
         assertion.isclose(value, ref, abs_tol=0.001)
@@ -66,3 +66,9 @@ def test_call():
             df = pd.DataFrame({'param': param['param'][0], 'max': param['min']})
             msg = f"iteration{i}\n{df.round(2)}"
             raise AssertionError(msg) from ex
+
+    if failed_iterations:
+        warning = RuntimeWarning("Failed to conserve the net charge in the "
+                                 f"following iterations: {failed_iterations!r}")
+        warning.__cause__ = ex_backup
+        warnings.warn(warning)


### PR DESCRIPTION
Implementation of https://github.com/nlesc-nano/auto-FOX/issues/121:
* Allow users to apply more complex charge constraints.
* Store frozen parameters in `ParamMapping["param"]`; mark them via the new `ParamMapping["constant"]` series.
* Made``ChargeError`` pickleable.

Examples
---------
``` yaml
param:
    charge:
        constraints:
            - 'Cd == -4*O - 2*C - 2*H == ...'  # Insert more constraints here (or not)
            - '1 < Cd < 2'
            - '-1 > Se > -2'
            - '0 > O > -1'
        param: charge
        ...
```
``` yaml
param:
    charge:
        constraints:
            - 'Cd == -2 * $LIGAND'  # An alias for all atoms within a ligand
        param: charge
        ...
```