### PR TITLE
BUG: Fixed three constraint-related bugs

### DIFF
--- a/FOX/armc/sanitization.py
+++ b/FOX/armc/sanitization.py
@@ -234,9 +234,10 @@ def get_param(dct: ParamMapping_) -> Tuple[ParamMapping, dict, dict]:
     constraints, min_max = _get_prm_constraints(_sub_prm_dict)
     data[['min', 'max']] = min_max
 
-    for *_key, value in _get_prm(_sub_prm_dict_frozen):
-        key = tuple(_key)
-        data.loc[key, :] = [value, True, -np.inf, np.inf]
+    if _sub_prm_dict_frozen is not None:
+        for *_key, value in _get_prm(_sub_prm_dict_frozen):
+            key = tuple(_key)
+            data.loc[key, :] = [value, True, -np.inf, np.inf]
     data.sort_index(inplace=True)
 
     param_type = prm_dict.pop('type')  # type: ignore

--- a/FOX/armc/sanitization.py
+++ b/FOX/armc/sanitization.py
@@ -237,7 +237,7 @@ def get_param(dct: ParamMapping_) -> Tuple[ParamMapping, dict, dict]:
     if _sub_prm_dict_frozen is not None:
         for *_key, value in _get_prm(_sub_prm_dict_frozen):
             key = tuple(_key)
-            data.loc[key, :] = [value, True, -np.inf, np.inf]
+            data.loc[key, :] = [value, value, True, -np.inf, np.inf]
     data.sort_index(inplace=True)
 
     param_type = prm_dict.pop('type')  # type: ignore
@@ -417,6 +417,7 @@ def _get_param_df(dct: Mapping[str, Any]) -> pd.DataFrame:
     df = pd.DataFrame(data, columns=columns)
     df.set_index(['key', 'param_type', 'atoms'], inplace=True)
 
+    df['param_old'] = df['param'].copy()
     df['constant'] = False
     df['min'] = -np.inf
     df['max'] = np.inf
@@ -537,6 +538,7 @@ def _parse_ligand_alias(psf_list: Optional[List[PSFContainer]], prm: ParamMappin
             key = ('charge', 'charge', k)
             if key not in prm['param'].index:
                 prm['param'].loc[key] = df.loc[df['atom type'] == k, 'charge'].iloc[0]
+                prm['param_old'].loc[key] = prm['param'].loc[key]
                 prm['min'][key] = -np.inf
                 prm['max'][key] = np.inf
                 prm['constant'][key] = True

--- a/FOX/functions/charge_parser.py
+++ b/FOX/functions/charge_parser.py
@@ -76,7 +76,11 @@ def assign_constraints(constraints: Union[str, Iterable[str]]
 def _gt_lt_constraints(constrain: List[str]
                        ) -> Generator[Tuple[Tuple[str, str], float], None, None]:
     r"""Parse :math:`>`, :math:`<`, :math:`\ge` and :math:`\le`-type constraints."""
+    minus = False
     for i, j in enumerate(constrain):
+        if j == '-':
+            minus = True
+            continue
         if j not in _OPPERATOR_MAPPING:
             continue
 
@@ -84,6 +88,9 @@ def _gt_lt_constraints(constrain: List[str]
         if isinstance(atom, float):
             atom, value = value, atom
             operator = _INVERT[operator]
+        if minus:
+            value *= -1
+            minus = False
         yield (atom, operator), value
 
 

--- a/tests/test_charge_parser.py
+++ b/tests/test_charge_parser.py
@@ -10,8 +10,8 @@ def test_assign_constraints() -> None:
     constraints = [
         'H < 1',
         'C >2.0',
-        '3.0> N',
-        '4<O',
+        '-3.0> N',
+        '- 4<O',
         '1 < F< 2.0',
         '2 > P >1.0',
         'S == 2 * Cl == 0.5*Br + -1.5*K - 1*Na == 1* I',
@@ -22,8 +22,8 @@ def test_assign_constraints() -> None:
     extremite_ref = {
         ('H', 'max'): 1.0,
         ('C', 'min'): 2.0,
-        ('N', 'max'): 3.0,
-        ('O', 'min'): 4.0,
+        ('N', 'max'): -3.0,
+        ('O', 'min'): -4.0,
         ('F', 'min'): 1.0,
         ('F', 'max'): 2.0,
         ('P', 'max'): 2.0,


### PR DESCRIPTION
Fixes 3 issue introduced in https://github.com/nlesc-nano/auto-FOX/pull/124:
* Check if `_sub_prm_dict_frozen` is `None` before iteration.
* Also add constants to `ParamMapping['param_old']`.
* Fixed an issue where negative extremites weren't properly parsed .