### PR TITLE
BUG: Attempt to fix a h5py-related exception

### DIFF
--- a/FOX/io/hdf5_utils.py
+++ b/FOX/io/hdf5_utils.py
@@ -28,6 +28,7 @@ API
 
 import warnings
 import subprocess
+import textwrap
 from os import remove, PathLike
 from time import sleep
 from os.path import isfile
@@ -331,6 +332,15 @@ def hdf5_availability(filename: PathType, timeout: float = 5.0,
     raise error
 
 
+_HDF5_EXC = """Failed to write dataset {key!r}
+
+dset: {dset.__class__.__name__} = {dset!r}
+kappa: {kappa.__class__.__name__} = {kappa!r}
+omega: {omega.__class__.__name__} = {omega!r}
+value: {value.__class__.__name__} = {value}
+"""
+
+
 def to_hdf5(filename: PathType, dset_dict: Mapping[str, np.ndarray],
             kappa: int, omega: int) -> None:
     r"""Export results from **dset_dict** to the hdf5 file **filename**.
@@ -372,8 +382,11 @@ def to_hdf5(filename: PathType, dset_dict: Mapping[str, np.ndarray],
                 else:
                     dset[kappa, omega] = np.asarray(value, dtype=dset.dtype)
             except Exception as ex:
-                cls = type(ex)
-                raise cls(f"dataset {key!r}: {ex}").with_traceback(ex.__traceback__)
+                value_str = textwrap.indent(repr(value), 27 * ' ')[27:]
+                msg = _HDF5_EXC.format(
+                    key=key, dset=dset, kappa=kappa, omega=omega, value=value_str,
+                )
+                raise RuntimeError(msg) from ex
 
     # Update the second hdf5 file with Cartesian coordinates
     filename_xyz = _get_filename_xyz(filename)

--- a/FOX/io/hdf5_utils.py
+++ b/FOX/io/hdf5_utils.py
@@ -365,10 +365,12 @@ def to_hdf5(filename: PathType, dset_dict: Mapping[str, np.ndarray],
             try:
                 if key == 'xyz':
                     continue
-                elif key == 'phi':
-                    f[key][kappa] = value
+
+                dset = f[key]
+                if key == 'phi':
+                    dset[kappa] = np.asarray(value, dtype=dset.dtype)
                 else:
-                    f[key][kappa, omega] = value
+                    dset[kappa, omega] = np.asarray(value, dtype=dset.dtype)
             except Exception as ex:
                 cls = type(ex)
                 raise cls(f"dataset {key!r}: {ex}").with_traceback(ex.__traceback__)


### PR DESCRIPTION
`h5py` can sometimes crash with the following exception:

```python
Traceback (most recent call last):
  File "/home/pascazio/miniconda3/envs/nano/lib/python3.9/site-packages/FOX/io/hdf5_utils.py", line 371, in to_hdf5
    f[key][kappa, omega] = value
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "/home/pascazio/miniconda3/envs/nano/lib/python3.9/site-packages/h5py/_hl/dataset.py", line 708, in __setitem__
    self.id.write(mspace, fspace, val, mtype, dxpl=self._dxpl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5d.pyx", line 221, in h5py.h5d.DatasetID.write
  File "h5py/_proxy.pyx", line 132, in h5py._proxy.dset_rw
  File "h5py/_proxy.pyx", line 93, in h5py._proxy.H5PY_H5Dwrite
OSError: Can't write data (no appropriate function for conversion path)

```
While the cause of the problem is still not 100% clear, this PR attempts to fix the issue.
At the very least a more descriptive error message will now be produced.

Pinging @juliette1996 and @RobertaPascazio.
