### PR TITLE
REL: Auto-FOX 0.8.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,20 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+0.8.8
+*****
+* Added recipes for calculating time-resolved angular/radial distribution functions.
+* Various documentation-related updates.
+* The order in wich atom-pair/-triplet based parameters are provided is now irrelevant.
+  For example ``Cd Se`` and ``Se Cd`` are now treated as equivalent, as well as
+  ``O C H`` and ``H C O`` (but not ``O H C``).
+* Fixed an issue where guessed parameters were not properly parsed.
+* Relaxed the PLAMS version requirement.
+* Log all local variables whenever an exception is encountered.
+* Move the ARMC test files to their own repo.
+* Export parameter metadata to the .hdf5 file.
+
+
 0.8.7
 *****
 * Moved from `PRMContainer.__dict__` to a `PRMContainer.__slots__` based class structure.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,18 +22,18 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 0.8.7
 *****
-* Moved from `PRMContainer.__dict__` to a `PRMContainer.__slots__` based class structure.
-* Cleaned up the `PRMContainer` code; updated annotations, etc..
-* Removed `assertionlib.AbstractDataClass` as base class from `PRMContainer`.
+* Moved from ``PRMContainer.__dict__`` to a ``PRMContainer.__slots__`` based class structure.
+* Cleaned up the ``PRMContainer`` code; updated annotations, *etc.*.
+* Removed ``assertionlib.AbstractDataClass`` as base class from ``PRMContainer``.
 * Do not read or write comments to and from a .prm file.
-* Upped the minimum Sphinx version to `2.1`.
-* Removed `sphinx-autodoc-typehints`.
+* Upped the minimum Sphinx version to ``2.1``.
+* Removed ``sphinx-autodoc-typehints``.
 
 
 0.8.6
 *****
-* Import `AbstractFileContainer` from Nano-Utils.
-* Removed `TypeMapping` in favor of `TypedDict`.
+* Import ``AbstractFileContainer`` from Nano-Utils.
+* Removed ``TypeMapping`` in favor of `TypedDict`.
 * Remove travis in favor of GitHub Actions.
 
 

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.8.7'
+__version__ = '0.8.8'

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@
 
 
 #################################################
-Automated Forcefield Optimization Extension 0.8.7
+Automated Forcefield Optimization Extension 0.8.8
 #################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = f'{_year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.8.7'  # The full version, including alpha/beta/rc tags.
+release = '0.8.8'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 


### PR DESCRIPTION
0.8.8
-----

* Added recipes for calculating time-resolved angular/radial distribution functions.
* Various documentation-related updates.
* The order in wich atom-pair/-triplet based parameters are provided is now irrelevant.
  For example ``Cd Se`` and ``Se Cd`` are now treated as equivalent, as well as ``O C H`` and ``H C O`` (but not ``O H C``).
* Fixed an issue where the ARMC procedure would occasionally crash when writing to the .hdf5 file.