### PR TITLE
ENH: Log all local variables whenever an exception is encountered

### DIFF
--- a/FOX/armc/run_armc.py
+++ b/FOX/armc/run_armc.py
@@ -20,6 +20,7 @@ from contextlib import redirect_stdout
 from scm.plams import config
 from qmflows.utils import InitRestart
 
+from ..utils import log_traceback_locals
 from ..logger import Plams2Logger, wrap_plams_logger
 
 if TYPE_CHECKING:
@@ -57,7 +58,13 @@ def run_armc(armc: MonteCarloABC,
                               lambda n: 'Trying to obtain results of crashed or failed job' in n)
 
         with redirect_stdout(writer):
-            if not restart:  # To restart or not? That's the question
-                armc()
-            else:
-                armc.restart()
+            try:
+                if not restart:  # To restart or not? That's the question
+                    armc()
+                else:
+                    armc.restart()
+            except Exception:
+                logger = armc.logger
+                logger.debug("Unexpected exception encounterd, dumping local variables:")
+                log_traceback_locals(logger)
+                raise

--- a/FOX/io/hdf5_utils.py
+++ b/FOX/io/hdf5_utils.py
@@ -28,7 +28,6 @@ API
 
 import warnings
 import subprocess
-import textwrap
 from os import remove, PathLike
 from time import sleep
 from os.path import isfile
@@ -332,15 +331,6 @@ def hdf5_availability(filename: PathType, timeout: float = 5.0,
     raise error
 
 
-_HDF5_EXC = """Failed to write dataset {key!r}
-
-dset: {dset.__class__.__name__} = {dset!r}
-kappa: {kappa.__class__.__name__} = {kappa!r}
-omega: {omega.__class__.__name__} = {omega!r}
-value: {value_cls.__name__} = {value}
-"""
-
-
 def to_hdf5(filename: PathType, dset_dict: Mapping[str, np.ndarray],
             kappa: int, omega: int) -> None:
     r"""Export results from **dset_dict** to the hdf5 file **filename**.
@@ -382,12 +372,7 @@ def to_hdf5(filename: PathType, dset_dict: Mapping[str, np.ndarray],
                 else:
                     dset[kappa, omega] = np.asarray(value, dtype=dset.dtype)
             except Exception as ex:
-                value_str = textwrap.indent(repr(value), 27 * ' ')[27:]
-                msg = _HDF5_EXC.format(
-                    key=key, dset=dset, kappa=kappa, omega=omega,
-                    value_cls=type(value), value=value_str,
-                )
-                raise RuntimeError(msg) from ex
+                raise RuntimeError(f'Failed to write dataset {key!r}') from ex
 
     # Update the second hdf5 file with Cartesian coordinates
     filename_xyz = _get_filename_xyz(filename)


### PR DESCRIPTION
All local variables will now be logged (at the `DEBUG` level) whenever exception is raised during the ARMC procedure.

The variables are extracted from the namespace where the upper-most exception was raised,
*i.e.* it will *not* recursively traverse the exception namespaces in the case of exception-chaining.

Examples
----------
```
[14:12:05] INFO: Moving epsilon (Cd O_1): 1.8340 -> 1.8707
[14:12:05] INFO: Rejecting move (0, 0): error_change = 0.0202; error = 0.1909

[14:12:05] DEBUG: Unexpected exception encounterd, dumping local variables:
[14:12:05] DEBUG:     filename: str = '/Users/bvanbeek/Documents/GitHub/auto-FOX/tests/test_files/_ARMC/armc.hdf5'
[14:12:05] DEBUG:     dset_dict: dict = {'acceptance': False,
[14:12:05] DEBUG:                        'aux_error': array([[0.19093411]]),
[14:12:05] DEBUG:                        'aux_error_mod': array([ 0.52   ,  0.4524 ,  0.9768 ,  0.     , -0.76   , -0.47041,
[14:12:05] DEBUG:                              -0.9768 ,  0.3101 ,  1.834  ,  1.5225 ,  1.6135 ,  0.4266 ,
[14:12:05] DEBUG:                               0.1234 ,  0.2471 ,  0.294  ,  0.3526 ,  0.4852 ,  1.     ]),
[14:12:05] DEBUG:                        'param': array([[ 0.52    ,  0.4524  ,  0.9768  ,  0.      , -0.76    , -0.47041 ,
[14:12:05] DEBUG:                               -0.9768  ,  0.316302,  1.87068 ,  1.55295 ,  1.64577 ,  0.435132,
[14:12:05] DEBUG:                                0.1234  ,  0.2471  ,  0.294   ,  0.3526  ,  0.4852  ]]),
[14:12:05] DEBUG:                        'phi': array([1.]),
[14:12:05] DEBUG:                        'rdf.0': Atom pairs         Cd Cd     Cd Se      Cd O     Se Se      Se O       O O
[14:12:05] DEBUG:                       r  /  Angstrom                                                            
[14:12:05] DEBUG:                       0.00            0.000000  0.000000  0.000000  0.000000  0.000000  0.000000
[14:12:05] DEBUG:                       0.05            0.000000  0.000000  0.000000  0.000000  0.000000  0.000000
[14:12:05] DEBUG:                       0.10            0.000000  0.000000  0.000000  0.000000  0.000000  0.000000
[14:12:05] DEBUG:                       0.15            0.000000  0.000000  0.000000  0.000000  0.000000  0.000000
[14:12:05] DEBUG:                       0.20            0.000000  0.000000  0.000000  0.000000  0.000000  0.000000
[14:12:05] DEBUG:                       ...                  ...       ...       ...       ...       ...       ...
[14:12:05] DEBUG:                       11.80           0.181056  0.243603  0.193702  0.395850  0.137800  0.196311
[14:12:05] DEBUG:                       11.85           0.200548  0.206571  0.182802  0.333405  0.144881  0.216046
[14:12:05] DEBUG:                       11.90           0.172985  0.225174  0.178750  0.300132  0.158240  0.190099
[14:12:05] DEBUG:                       11.95           0.146764  0.253746  0.165146  0.251301  0.164948  0.207992
[14:12:05] DEBUG:                       12.00           0.146503  0.202714  0.191871  0.273139  0.162781  0.226258
[14:12:05] DEBUG: 
[14:12:05] DEBUG:                       [241 rows x 6 columns],
[14:12:05] DEBUG:                        'xyz': [MultiMolecule(..., shape=(101, 227, 3), dtype='float64')]}
[14:12:05] DEBUG:     kappa: int = 0
[14:12:05] DEBUG:     omega: int = 0
[14:12:05] DEBUG:     f: File = <Closed HDF5 file>
[14:12:05] DEBUG:     key: str = 'param'
[14:12:05] DEBUG:     value: ndarray = array([[ 0.52    ,  0.4524  ,  0.9768  ,  0.      , -0.76    , -0.47041 ,
[14:12:05] DEBUG:                              -0.9768  ,  0.316302,  1.87068 ,  1.55295 ,  1.64577 ,  0.435132,
[14:12:05] DEBUG:                               0.1234  ,  0.2471  ,  0.294   ,  0.3526  ,  0.4852  ]])
[14:12:05] DEBUG:     dset: Dataset = <Closed HDF5 dataset>

```