### PR TITLE
ENH: Export more parameters to the .hdf5 file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ coverage.xml
 *.pot
 
 # Django stuff:
-*.log
 local_settings.py
 db.sqlite3
 
@@ -65,7 +64,6 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-docs_out/
 
 # PyBuilder
 target/
@@ -109,4 +107,3 @@ venv.bak/
 
 # Visual Studio Code
 .vscode/
-MM_MD_workdir*/

--- a/FOX/armc/sanitization.py
+++ b/FOX/armc/sanitization.py
@@ -164,7 +164,8 @@ def _guess_param(mc: MonteCarloABC, prm: dict,
             param_mapping['min'][key] = -np.inf
             param_mapping['max'][key] = np.inf
             param_mapping['count'][key] = 0
-            param_mapping['constant'][key] = frozen
+            param_mapping['frozen'][key] = frozen
+            param_mapping['guess'][key] = True
     return
 
 
@@ -416,7 +417,8 @@ def _get_param_df(dct: Mapping[str, Any]) -> pd.DataFrame:
     df.set_index(['key', 'param_type', 'atoms'], inplace=True)
 
     df['param_old'] = df['param'].copy()
-    df['constant'] = False
+    df['frozen'] = False
+    df['guess'] = False
     df['min'] = -np.inf
     df['max'] = np.inf
     df['count'] = 0

--- a/FOX/armc/sanitization.py
+++ b/FOX/armc/sanitization.py
@@ -99,7 +99,6 @@ def dict_to_armc(input_dict: MainMapping) -> Tuple[MonteCarloABC, RunDict]:
     # Handle psf stuff
     psf_list: Optional[List[PSFContainer]] = get_psf(dct['psf'], mol_list)
     run_kwargs['psf'] = psf_list
-    update_count(param, psf=psf_list, mol=mol_list)
     _parse_ligand_alias(psf_list, prm=param)
     if psf_list is not None:
         mc.pes_post_process = [AtomsFromPSF.from_psf(*psf_list)]
@@ -110,14 +109,18 @@ def dict_to_armc(input_dict: MainMapping) -> Tuple[MonteCarloABC, RunDict]:
     if _param_frozen is not None:
         _guess_param(mc, _param_frozen, frozen=True, psf=psf_list)
     _guess_param(mc, _param, frozen=False, psf=psf_list)
+    update_count(param, psf=psf_list, mol=mol_list)
 
     mc.param['param'].sort_index(inplace=True)
     mc.param['param_old'].sort_index(inplace=True)
     mc.param['min'].sort_index(inplace=True)
     mc.param['max'].sort_index(inplace=True)
     mc.param['count'].sort_index(inplace=True)
-    mc.param['constant'].sort_index(inplace=True)
-    mc.param._data['constant'] = mc.param['constant'].astype(bool, copy=False)
+    mc.param['frozen'].sort_index(inplace=True)
+    mc.param['guess'].sort_index(inplace=True)
+    mc.param._data['count'] = mc.param['count'].astype(int, copy=False)
+    mc.param._data['frozen'] = mc.param['frozen'].astype(bool, copy=False)
+    mc.param._data['guess'] = mc.param['guess'].astype(bool, copy=False)
 
     # Add PES evaluators
     pes = get_pes(dct['pes'])
@@ -237,7 +240,7 @@ def get_param(dct: ParamMapping_) -> Tuple[ParamMapping, dict, dict]:
     if _sub_prm_dict_frozen is not None:
         for *_key, value in _get_prm(_sub_prm_dict_frozen):
             key = tuple(_key)
-            data.loc[key, :] = [value, value, True, -np.inf, np.inf]
+            data.loc[key, :] = [value, value, True, False, -np.inf, np.inf, 0]
     data.sort_index(inplace=True)
 
     param_type = prm_dict.pop('type')  # type: ignore
@@ -416,6 +419,7 @@ def _get_param_df(dct: Mapping[str, Any]) -> pd.DataFrame:
     df['constant'] = False
     df['min'] = -np.inf
     df['max'] = np.inf
+    df['count'] = 0
     return df
 
 
@@ -580,7 +584,9 @@ def _parse_ligand_alias(psf_list: Optional[List[PSFContainer]], prm: ParamMappin
                 prm['param_old'].loc[key] = prm['param'].loc[key]
                 prm['min'][key] = -np.inf
                 prm['max'][key] = np.inf
-                prm['constant'][key] = True
+                prm['frozen'][key] = True
+                prm['guess'][key] = False
+                prm['count'][key] = 0
 
     for lst in prm.constraints.values():
         for series in lst:

--- a/FOX/io/hdf5_utils.py
+++ b/FOX/io/hdf5_utils.py
@@ -93,6 +93,21 @@ def create_hdf5(filename: PathType, armc: ARMC) -> None:
         f.attrs['sub-iteration'] = -1
         f.attrs['__version__'] = np.fromiter(__version__.split('.'), count=3, dtype=int)
 
+        str_dtype = h5py.string_dtype(encoding='ascii')
+        index: np.ndarray = armc.param['param'].index
+        index_dtype = np.dtype(list((k, str_dtype) for k in index.names))
+
+        dset = f.create_dataset(name='param_metadata', data=armc.param.to_struct_array())
+        dset.attrs['index'] = index.values.astype(index_dtype)
+        dset.attrs['net_charge'] = armc.param._net_charge
+        dset.attrs['move_range'] = armc.param.move_range
+
+        constraints = armc.param.constraints_to_str()
+        index2: np.ndarray = constraints.index
+        index2_dtype = np.dtype(list((k, str_dtype) for k in index2.names))
+        dset.attrs['constraints'] = constraints.values.astype(str_dtype)
+        dset.attrs['constraints_index'] = index2.values.astype(index2_dtype)
+
     # Store the *index*, *column* and *name* attributes of dataframes/series in the hdf5 file
     kappa = armc.iter_len // armc.sub_iter_len
     idx = armc.param['param'][0].index.append(pd.MultiIndex.from_tuples([('', 'phi', '')]))

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ tests_require = [
     'pyflakes>=2.1.1',
     'pytest-flake8>=1.0.5',
     'pytest-pydocstyle>=2.1',
-    'auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.0.0',
+    'auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.1',
 ]
 tests_require += docs_require
 

--- a/tests/test_hdf5_utils.py
+++ b/tests/test_hdf5_utils.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from scm.plams import Settings
 from assertionlib import assertion
+from nanoutils import delete_finally
 
 import FOX
 from FOX.armc import dict_to_armc
@@ -17,6 +18,7 @@ from FOX.io.hdf5_utils import create_hdf5, to_hdf5, from_hdf5, create_xyz_hdf5
 PATH: str = join('tests', 'test_files')
 
 
+@delete_finally(join(PATH, 'test.hdf5'))
 def test_create_hdf5():
     """Test :meth:`FOX.io.hdf5_utils.create_hdf5`."""
     yaml_file = join(PATH, 'armc.yaml')
@@ -26,28 +28,27 @@ def test_create_hdf5():
 
     ref_dict = Settings()
     ref_dict.acceptance.shape = 500, 100, 1
-    ref_dict.acceptance.dtype = bool
+    ref_dict.acceptance.dtype = np.bool_
     ref_dict.aux_error.shape = 500, 100, 1, 1
-    ref_dict.aux_error.dtype = np.float
+    ref_dict.aux_error.dtype = np.float64
     ref_dict.aux_error_mod.shape = 500, 100, 1, 16
-    ref_dict.aux_error_mod.dtype = np.float
+    ref_dict.aux_error_mod.dtype = np.float64
     ref_dict.param.shape = 500, 100, 1, 15
-    ref_dict.param.dtype = np.float
+    ref_dict.param.dtype = np.float64
+    ref_dict.param_metadata.shape = (15,)
+    ref_dict.param_metadata.dtype = np.void
     ref_dict.phi.shape = 500, 1
-    ref_dict.phi.dtype = np.float
+    ref_dict.phi.dtype = np.float64
     ref_dict['rdf.0'].shape = 500, 100, 241, 6
-    ref_dict['rdf.0'].dtype = np.float
+    ref_dict['rdf.0'].dtype = np.float64
     ref_dict['rdf.0.ref'].shape = 241, 6
-    ref_dict['rdf.0.ref'].dtype = np.float
+    ref_dict['rdf.0.ref'].dtype = np.float64
 
-    try:
-        create_hdf5(hdf5_file, armc)
-        with h5py.File(hdf5_file, 'r') as f:
-            for key, value in f.items():
-                assertion.shape_eq(value, ref_dict[key].shape, message=key)
-                assertion.isinstance(value[:].item(0), ref_dict[key].dtype, message=key)
-    finally:
-        remove(hdf5_file) if isfile(hdf5_file) else None
+    create_hdf5(hdf5_file, armc)
+    with h5py.File(hdf5_file, 'r') as f:
+        for key, value in f.items():
+            assertion.shape_eq(value, ref_dict[key].shape, message=key)
+            assertion.isinstance(value[:].take(0), ref_dict[key].dtype, message=key)
 
 
 def test_to_hdf5():

--- a/tests/test_param_mapping.py
+++ b/tests/test_param_mapping.py
@@ -1,5 +1,7 @@
 """A module for testing :mod:`FOX.armc.param_mapping`."""
+
 import warnings
+import numpy as np
 import pandas as pd
 
 from assertionlib import assertion
@@ -24,7 +26,7 @@ _DF = pd.DataFrame({'param': _DATA})
 _DF['count'] = 2 * [26, 68, 26, 52, 55]
 _DF['min'] = _DF['param'] - 0.5 * abs(_DF['param'])
 _DF['max'] = _DF['param'] + 0.5 * abs(_DF['param'])
-_DF['constant'] = 2 * [False, False, True, False, False]
+_DF['frozen'] = 2 * [False, False, True, False, False]
 
 _CONSTRAINTS = {
     ('charge', 'charge'): [{'Cd': 1.0}, {'O': -4.0, 'C': -2.0, 'H': -2.0}]
@@ -54,14 +56,14 @@ def test_call():
         assertion.isclose(value, ref, abs_tol=0.001)
 
         try:
-            assert (param['param'][0] <= param['max']).all()
+            assertion.le(param['param'][0], param['max'], post_process=np.all)
         except AssertionError as ex:
             df = pd.DataFrame({'param': param['param'][0], 'max': param['max']})
             msg = f"iteration{i}\n{df.round(2)}"
             raise AssertionError(msg) from ex
 
         try:
-            assert (param['param'][0] >= param['min']).all()
+            assertion.ge(param['param'][0], param['min'], post_process=np.all)
         except AssertionError as ex:
             df = pd.DataFrame({'param': param['param'][0], 'max': param['min']})
             msg = f"iteration{i}\n{df.round(2)}"


### PR DESCRIPTION
Closes https://github.com/nlesc-nano/auto-FOX/issues/149.

Adds a new `param_metadata` structured dataset that Includes the likes of:
* The min/max values
* Whether a parameter is guessed and/or frozen
* The number of atoms/pairs/triplets for a given parameter
* The net charge (attribute)
* The move range (attribute)
* The constraints (attribute)