### PR TITLE
ENH: Added the new `param.validation.allow_non_existent` keyword

### DIFF
--- a/FOX/logger.py
+++ b/FOX/logger.py
@@ -55,7 +55,8 @@ def wrap_plams_logger(logfile: Union[None, str, os.PathLike] = None,
     config.log.file = 0
 
     # Replace the plams logger with a proper logging.Logger instance
-    os.remove(plams_logfile)
+    if os.path.isfile(plams_logfile):
+        os.remove(plams_logfile)
     logger = get_logger(name, handlers=[FileHandler(logfile), StreamHandler()], **kwargs)
     if plams_logfile != logfile:
         try:

--- a/docs/4_monte_carlo_args.rst
+++ b/docs/4_monte_carlo_args.rst
@@ -16,6 +16,7 @@ Index
     :attr:`param.move_range`                    The parameter move range.
     :attr:`param.func`                          The callable for performing the Monte Carlo moves.
     :attr:`param.kwargs`                        A dictionary with keyword arguments for :attr:`param.func`.
+    :attr:`param.validation.allow_non_existent` Whether to allow parameters, that are explicitly specified, for absent atoms.
     :attr:`param.block.param`                   The name of the forcefield parameter.
     :attr:`param.block.unit`                    The unit in which the forcefield parameters are expressed.
     :attr:`param.block.constraints`             A string or list of strings with parameter constraints.
@@ -112,6 +113,8 @@ This settings block accepts an arbitrary number of sub-blocks.
                 ratio: null
             func: numpy.multiply
             kwargs: {}
+            validation:
+                allow_non_existent: False
 
             charge:
                 param: charge
@@ -196,6 +199,14 @@ This settings block accepts an arbitrary number of sub-blocks.
                         * **Default Value** - ``{}``
 
         A dictionary with keyword arguments for :attr:`param.func`.
+
+
+    .. attribute:: param.validation.allow_non_existent
+
+        :Parameter:     * **Type** - :class:`bool`
+                        * **Default Value** - :data:`False`
+
+        Whether to allow parameters, that are explicitly specified, for absent atoms.
 
 
     .. attribute:: param.block.param

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ tests_require = [
     'pyflakes>=2.1.1',
     'pytest-flake8>=1.0.5',
     'pytest-pydocstyle>=2.1',
-    'auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.1',
+    'auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.2',
 ]
 tests_require += docs_require
 

--- a/tests/test_armc.py
+++ b/tests/test_armc.py
@@ -46,11 +46,9 @@ def test_armc_guess() -> None:
         2.53727955,
         2.07044862,
         2.7831676,
-        0.2471,
         3.14175433,
         2.6749234,
         3.38764238,
-        0.3526,
         3.74622911,
     ])
     np.testing.assert_allclose(param.values, ref)
@@ -92,7 +90,7 @@ def test_armc() -> None:
 
     hdf5 = PATH / '_ARMC' / 'armc.hdf5'
     hdf5_ref = ARMC_REF / 'armc.hdf5'
-    with h5py.File(hdf5, 'r') as f1, h5py.File(hdf5_ref, 'r') as f2:
+    with h5py.File(hdf5, 'r') as f1, h5py.File(hdf5_ref, 'r+') as f2:
         compare_hdf5(f1, f2, skip={'param', 'aux_error_mod'})
 
 
@@ -118,7 +116,7 @@ def test_armcpt() -> None:
 
     hdf5 = PATH / '_ARMCPT' / 'armc.hdf5'
     hdf5_ref = ARMCPT_REF / 'armc.hdf5'
-    with h5py.File(hdf5, 'r') as f1, h5py.File(hdf5_ref, 'r') as f2:
+    with h5py.File(hdf5, 'r') as f1, h5py.File(hdf5_ref, 'r+') as f2:
         compare_hdf5(f1, f2, skip={'param', 'aux_error_mod'})
 
 

--- a/tests/test_files/armc_ref.yaml
+++ b/tests/test_files/armc_ref.yaml
@@ -7,27 +7,27 @@ param:
             - 'Cd == -2 * $LIGAND'
             - '0 < Cd < 2'
             - '-2 < Se < 0'
-            - '-1 < O_1 < 0'
-            - '0 < C_1 < 1'
+            - '-1 < OG2D2 < 0'
+            - '0 < CG2O3 < 1'
         Cd: 0.9768
         Se: -0.9768
-        O_1: -0.47041
-        C_1: 0.4524
+        OG2D2: -0.47041
+        CG2O3: 0.4524
     lennard_jones:
         -   unit: kjmol
             param: epsilon
             Cd Cd: 0.3101
             Se Se: 0.4266
             Cd Se: 1.5225
-            Cd O_1: 1.8340
-            Se O_1: 1.6135
+            Cd OG2D2: 1.8340
+            Se OG2D2: 1.6135
         -   unit: nm
             param: sigma
             Cd Cd: 0.1234
             Se Se: 0.4852
             Cd Se: 0.2940
-            Cd O_1: 0.2471
-            Se O_1: 0.3526
+            Cd OG2D2: 0.2471
+            Se OG2D2: 0.3526
 
 psf:
     str_file: tests/test_files/ligand.str

--- a/tests/test_files/armcpt_ref.yaml
+++ b/tests/test_files/armcpt_ref.yaml
@@ -12,27 +12,27 @@ param:
             - 'Cd == -2 * $LIGAND'
             - '0 < Cd < 2'
             - '-2 < Se < 0'
-            - '-1 < O_1 < 0'
-            - '0 < C_1 < 1'
+            - '-1 < OG2D2 < 0'
+            - '0 < CG2O3 < 1'
         Cd: 0.9768
         Se: -0.9768
-        O_1: -0.47041
-        C_1: 0.4524
+        OG2D2: -0.47041
+        CG2O3: 0.4524
     lennard_jones:
         -   unit: kjmol
             param: epsilon
             Cd Cd: 0.3101
             Se Se: 0.4266
             Cd Se: 1.5225
-            Cd O_1: 1.8340
-            Se O_1: 1.6135
+            Cd OG2D2: 1.8340
+            Se OG2D2: 1.6135
         -   unit: nm
             param: sigma
             Cd Cd: 0.1234
             Se Se: 0.4852
             Cd Se: 0.2940
-            Cd O_1: 0.2471
-            Se O_1: 0.3526
+            Cd OG2D2: 0.2471
+            Se OG2D2: 0.3526
 
 psf:
     str_file: tests/test_files/ligand.str


### PR DESCRIPTION
Closes https://github.com/nlesc-nano/auto-FOX/issues/153.

By default a `RuntimeError` will now be raised if parameters have been (explicitly) specified for non-existent atoms.
Using `param.validation.allow_non_existent = True` will instead merely issue a warning.