### PR TITLE
REL: Auto-FOX 0.8.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,20 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+0.8.9
+*****
+* Fixed an issue where frozen parameters were not respected when performing
+  contrained parameter updates.
+* Fixed an issue where the ARMCPT parameters weren't properly swapped.
+* Added two new ARMC options: ``param.validation.allow_non_existent``
+  and ``param.validation.charge_tolerance``.
+* Update the type hints within Auto-FOX.
+* Allow the ARMC(PT) input to, once again, be dumped to a .yaml file via
+  the ``armc2yaml`` command.
+* Dump more information into the ARMC logger.
+* Re-enable the ARMC restart option.
+
+
 0.8.8
 *****
 * Added recipes for calculating time-resolved angular/radial distribution functions.

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.8.8'
+__version__ = '0.8.9'

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@
 
 
 #################################################
-Automated Forcefield Optimization Extension 0.8.8
+Automated Forcefield Optimization Extension 0.8.9
 #################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and
@@ -90,7 +90,7 @@ Installing **Auto-FOX**
 
 - If using Conda, enable the environment: ``conda activate FOX``
 
-- Install **Auto-FOX** with PyPi: ``pip install git+https://github.com/nlesc-nano/auto-FOX@master --upgrade``
+- Install **Auto-FOX** with PyPi: ``pip install git+https://github.com/nlesc-nano/auto-FOX@0.8 --upgrade``
 
 - Congratulations, **Auto-FOX** is now installed and ready for use!
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = f'{_year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.8.8'  # The full version, including alpha/beta/rc tags.
+release = '0.8.9'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 


### PR DESCRIPTION
0.8.9
-----
* Fixed an issue where frozen parameters were not respected when performing constrained parameter updates.
* Fixed an issue where the ARMCPT parameters weren't properly swapped.
* Added two new ARMC options: ``param.validation.allow_non_existent`` and ``param.validation.charge_tolerance``.
* Update the type hints within Auto-FOX.
* Allow the ARMC(PT) input to, once again, be dumped to a .yaml file via the ``armc2yaml`` command.
* Dump more information into the ARMC logger.
* Re-enabled the ARMC restart option.

