### PR TITLE
MAINT: Reorganize the dataframes in `FOX.armc.ParamMapping`

### DIFF
--- a/FOX/armc/armc_pt.py
+++ b/FOX/armc/armc_pt.py
@@ -142,7 +142,7 @@ class ARMCPT(ARMC):
         ret = super()._parse_call(start, key_new)
         if start is key_new is None:
             self[ret] = self[ret][0]
-            i = len(self.param['param'].columns)
+            i = len(self.param.param.columns)
             return i * [ret]
         else:
             return list(ret)
@@ -235,7 +235,7 @@ class ARMCPT(ARMC):
             if acc:
                 self.logger.info(f"Accepting move {(kappa, omega)}: {epilog}")
                 self[k_new] = self.apply_phi(_aux_new, idx=i)
-                self.param['param_old'][i] = self.param['param'][i]
+                self.param.param_old[i] = self.param.param[i]
                 ret.append(k_new)
             else:
                 self.logger.info(f"Rejecting move {(kappa, omega)}: {epilog}")

--- a/FOX/armc/monte_carlo.py
+++ b/FOX/armc/monte_carlo.py
@@ -344,7 +344,7 @@ class MonteCarloABC(AbstractDataClass, ABC, Mapping[Key, np.ndarray]):
         else:
             key, prm_name, _ = ret
 
-        prm_update = self.param['param'][idx_].loc[(key, prm_name)].to_frame().T
+        prm_update = self.param.param.loc[(key, prm_name), idx_].to_frame().T
         prm_update.index = [prm_name]
         if idx is None:
             _iterator = chain.from_iterable(self.package_manager.values())
@@ -356,7 +356,7 @@ class MonteCarloABC(AbstractDataClass, ABC, Mapping[Key, np.ndarray]):
         for settings in iterator:
             settings[key].update(prm_update)
 
-        return cast(Key, tuple(self.param['param'][idx_].values))
+        return cast(Key, tuple(self.param.param[idx_].values))
 
     def get_pes_descriptors(self, get_first_key: bool = False,
                             ) -> Tuple[Dict[str, ArrayOrScalar], Optional[List[MultiMolecule]]]:

--- a/FOX/io/hdf5_utils.py
+++ b/FOX/io/hdf5_utils.py
@@ -94,7 +94,7 @@ def create_hdf5(filename: PathType, armc: ARMC) -> None:
         f.attrs['__version__'] = np.fromiter(__version__.split('.'), count=3, dtype=int)
 
         str_dtype = h5py.string_dtype(encoding='ascii')
-        index: pd.MultiIndex = armc.param['param'].index
+        index: pd.MultiIndex = armc.param.param.index
         index_dtype = np.dtype(list((k, str_dtype) for k in index.names))
 
         dset = f.create_dataset(name='param_metadata', data=armc.param.to_struct_array())
@@ -110,11 +110,11 @@ def create_hdf5(filename: PathType, armc: ARMC) -> None:
 
     # Store the *index*, *column* and *name* attributes of dataframes/series in the hdf5 file
     kappa = armc.iter_len // armc.sub_iter_len
-    idx = armc.param['param'][0].index.append(pd.MultiIndex.from_tuples([('', 'phi', '')]))
+    idx = armc.param.param[0].index.append(pd.MultiIndex.from_tuples([('', 'phi', '')]))
     aux_error_idx = list(armc.pes.keys())
 
     pd_dict = {
-        'param': armc.param['param'][0],
+        'param': armc.param.param[0],
         'phi': pd.Series(np.nan, index=np.arange(kappa), name='phi'),
         'aux_error': pd.Series(np.nan, index=aux_error_idx, name='aux_error'),
         'aux_error_mod': pd.Series(np.nan, index=idx, name='aux_error_mod')
@@ -249,7 +249,7 @@ def _get_kwarg_dict(armc: ARMC) -> Settings:
 
     """
     shape = armc.iter_len // armc.sub_iter_len, armc.sub_iter_len
-    param_shape = armc.param['param'].T.shape
+    param_shape = armc.param.param.T.shape
 
     ret = Settings()  # type: ignore[var-annotated]
     ret.phi.shape = (shape[0], ) + armc.phi.shape

--- a/tests/test_armc.py
+++ b/tests/test_armc.py
@@ -96,7 +96,7 @@ def test_armc_guess() -> None:
     sigma['frozen'] = {'guess': 'uff'}
 
     armc, job_kwargs = dict_to_armc(dct)
-    param = armc.param['param'].loc[('lennard_jones', 'sigma'), 0]
+    param = armc.param.param.loc[('lennard_jones', 'sigma'), 0]
 
     # The expected `sigma` parameters
     ref = np.array([

--- a/tests/test_param_mapping.py
+++ b/tests/test_param_mapping.py
@@ -7,7 +7,6 @@ import pandas as pd
 from assertionlib import assertion
 
 from FOX.armc import ParamMapping
-from FOX.testing_utils import validate_mapping
 
 _DATA = {
     ('charge', 'charge', 'C'): 0.4524,
@@ -35,15 +34,10 @@ _CONSTRAINTS = {
 PARAM = ParamMapping(_DF, constraints=_CONSTRAINTS)
 
 
-def test_mapping():
-    """Test the :class:`~collections.abc.Mapping` implementation of :class:`ParamMapping`."""
-    validate_mapping(PARAM, key_type=str, value_type=(pd.DataFrame, pd.Series))
-
-
 def test_call():
     """Test :meth:`ParamMapping.__call__`."""
     param = PARAM.copy(deep=True)
-    ref = sum(param['param'][0].loc['charge'] * param['count'].loc['charge'])
+    ref = sum(param.param.loc['charge', 0] * param.metadata.loc['charge', 'count'])
 
     failed_iterations = []
     for i in range(1000):
@@ -52,20 +46,20 @@ def test_call():
             failed_iterations.append(i)
             ex_backup = ex
 
-        value = sum(param['param'][0].loc['charge'] * param['count'].loc['charge'])
+        value = sum(param.param.loc['charge', 0] * param.metadata.loc['charge', 'count'])
         assertion.isclose(value, ref, abs_tol=0.001)
 
         try:
-            assertion.le(param['param'][0], param['max'], post_process=np.all)
+            assertion.le(param.param[0], param.metadata['max'], post_process=np.all)
         except AssertionError as ex:
-            df = pd.DataFrame({'param': param['param'][0], 'max': param['max']})
+            df = pd.DataFrame({'param': param.param[0], 'max': param.metadata['max']})
             msg = f"iteration{i}\n{df.round(2)}"
             raise AssertionError(msg) from ex
 
         try:
-            assertion.ge(param['param'][0], param['min'], post_process=np.all)
+            assertion.ge(param.param[0], param.metadata['min'], post_process=np.all)
         except AssertionError as ex:
-            df = pd.DataFrame({'param': param['param'][0], 'max': param['min']})
+            df = pd.DataFrame({'param': param.param[0], 'max': param.metadata['min']})
             msg = f"iteration{i}\n{df.round(2)}"
             raise AssertionError(msg) from ex
 


### PR DESCRIPTION
* Remove the `abc.Mapping` baseclass.
* Move all data to a set of three dataframes: `param`, `param_old` and `metadata`.