### PR TITLE
BUG: Dissallow the specification of duplicate .yaml keys

### DIFF
--- a/FOX/entry_points.py
+++ b/FOX/entry_points.py
@@ -27,12 +27,9 @@ from os.path import isfile, join
 from typing import Optional, List
 
 import yaml
-try:
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
 import h5py
 
+from .yaml import UniqueLoader
 from .armc import dict_to_armc, run_armc
 from .armc.csv_utils import dset_to_csv
 from .armc.plotting import plot_pes_descriptors, plot_param, plot_dset
@@ -68,7 +65,7 @@ def main_armc(args: Optional[list] = None) -> None:
     restart: bool = args_parsed.restart[0]
 
     with open(filename, 'r') as f:
-        dct = yaml.load(f.read(), Loader=Loader)
+        dct = yaml.load(f.read(), Loader=UniqueLoader)
     armc, kwargs = dict_to_armc(dct)
     run_armc(armc, restart=restart, **kwargs)
 

--- a/FOX/examples/cp2k_armc.py
+++ b/FOX/examples/cp2k_armc.py
@@ -6,7 +6,7 @@ from FOX.armc import dict_to_armc, run_armc
 # Prepare the ARMC settings
 file = str(...)
 with open(file, 'r') as f:
-    dct = yaml.load(f.read(), Loader=yaml.FullLoader)
+    dct = yaml.load(f.read(), Loader=yaml.SafeLoader)
 
 armc, kwargs = dict_to_armc(dct)
 run_armc(armc, **kwargs)

--- a/FOX/yaml.py
+++ b/FOX/yaml.py
@@ -1,0 +1,38 @@
+"""A module containing the :class:`UniqueLoader` class."""
+
+from collections.abc import Hashable
+from typing import Dict, Any
+
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader  # type: ignore[misc]
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode
+
+__all__ = ['UniqueLoader']
+
+
+class UniqueLoader(Loader):
+    """A special :class:`~yaml.Loader` with duplicate key checking."""
+
+    def construct_mapping(self, node: MappingNode, deep: bool = False) -> Dict[Any, Any]:
+        """Construct Convert the passed **node** into a :class:`dict`."""
+        if not isinstance(node, MappingNode):
+            raise ConstructorError(
+                None, None, f"expected a mapping node, but found {node.id}", node.start_mark
+            )
+
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if not isinstance(key, Hashable):
+                raise ConstructorError("while constructing a mapping", node.start_mark,
+                                       "found unhashable key", key_node.start_mark)
+            elif key in mapping:
+                raise ConstructorError("while constructing a mapping", node.start_mark,
+                                       "found a duplicate key", key_node.start_mark)
+
+            value = self.construct_object(value_node, deep=deep)
+            mapping[key] = value
+        return mapping

--- a/tests/test_armc.py
+++ b/tests/test_armc.py
@@ -15,6 +15,7 @@ import yaml
 from nanoutils import delete_finally
 from assertionlib import assertion
 
+from FOX.yaml import UniqueLoader
 from FOX.testing_utils import load_results, compare_hdf5
 from FOX.armc import dict_to_armc, run_armc
 from FOX.armc.sanitization import _sort_atoms
@@ -52,7 +53,7 @@ def test_armc_restart(name: str) -> None:
     """Test the restart functionality of :class:`ARMC` and :class:`ARMCPT`."""
     file = PATH / name
     with open(file, 'r') as f:
-        dct = yaml.load(f.read(), Loader=yaml.FullLoader)
+        dct = yaml.load(f.read(), Loader=UniqueLoader)
 
     sub_iter = 5
     super_iter = 8
@@ -89,7 +90,7 @@ def test_armc_restart(name: str) -> None:
 def test_armc_guess() -> None:
     file = PATH / 'armc_ref.yaml'
     with open(file, 'r') as f:
-        dct = yaml.load(f.read(), Loader=yaml.FullLoader)
+        dct = yaml.load(f.read(), Loader=UniqueLoader)
 
     sigma = dct['param']['lennard_jones'][1]
     del sigma['Cd Cd']
@@ -117,7 +118,7 @@ def test_allow_non_existent() -> None:
     """Test ``param.validation.allow_non_existent``."""
     file = PATH / 'armc_ref.yaml'
     with open(file, 'r') as f:
-        dct = yaml.load(f.read(), Loader=yaml.FullLoader)
+        dct = yaml.load(f.read(), Loader=UniqueLoader)
 
     # Test `param.validation.allow_non_existent`
     dct['param']['charge']['Cl'] = -1
@@ -138,7 +139,7 @@ def test_charge_tolerance() -> None:
     """Test ``param.validation.charge_tolerance``."""
     file = PATH / 'armc_ref.yaml'
     with open(file, 'r') as f:
-        dct = yaml.load(f.read(), Loader=yaml.FullLoader)
+        dct = yaml.load(f.read(), Loader=UniqueLoader)
 
     dct = dct.copy()
     dct['param']['charge']['Cd'] = 2
@@ -161,7 +162,7 @@ def test_armc(name: str) -> None:
     """Test :class:`ARMC` and :class:`ARMCPT`."""
     file = PATH / name
     with open(file, 'r') as f:
-        dct = yaml.load(f.read(), Loader=yaml.FullLoader)
+        dct = yaml.load(f.read(), Loader=UniqueLoader)
 
     armc, job_kwargs = dict_to_armc(dct)
     if name == 'armc_ref.yaml':
@@ -211,7 +212,7 @@ def test_yaml_armc(name: str) -> None:
     """Tests for :meth:`FOX.armc.ARMC.to_yaml_dict`."""
     file = PATH / name
     with open(file, 'r') as f:
-        _dct = yaml.load(f.read(), Loader=yaml.FullLoader)
+        _dct = yaml.load(f.read(), Loader=UniqueLoader)
 
     armc1, job_kwargs1 = dict_to_armc(_dct)
     dct1 = armc1.to_yaml_dict(

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -23,7 +23,7 @@ def test_cp2k_md():
     file = join(PATH, 'armc.yaml')
 
     with open(file, 'r') as f:
-        dct = yaml.load(f.read(), Loader=yaml.FullLoader)
+        dct = yaml.load(f.read(), Loader=yaml.SafeLoader)
     armc, job_kwarg = dict_to_armc(dct)
 
     assertion.isinstance(armc, ARMC)

--- a/tests/test_hdf5_utils.py
+++ b/tests/test_hdf5_utils.py
@@ -13,6 +13,7 @@ from assertionlib import assertion
 from nanoutils import delete_finally
 
 import FOX
+from FOX.yaml import UniqueLoader
 from FOX.armc import dict_to_armc
 from FOX.io.hdf5_utils import create_hdf5, to_hdf5, from_hdf5, create_xyz_hdf5, recursive_items
 
@@ -24,7 +25,7 @@ def test_create_hdf5():
     """Test :meth:`FOX.io.hdf5_utils.create_hdf5`."""
     yaml_file = PATH / 'armc.yaml'
     with open(yaml_file, 'r') as f:
-        armc, _ = dict_to_armc(yaml.load(f.read(), Loader=yaml.FullLoader))
+        armc, _ = dict_to_armc(yaml.load(f.read(), Loader=UniqueLoader))
     armc.hdf5_file = hdf5_file = PATH / 'test.hdf5'
 
     ref_dict = Settings()
@@ -59,7 +60,7 @@ def test_to_hdf5():
     """Test :meth:`FOX.io.hdf5_utils.to_hdf5`."""
     yaml_file = PATH / 'armc.yaml'
     with open(yaml_file, 'r') as f:
-        armc, _ = dict_to_armc(yaml.load(f.read(), Loader=yaml.FullLoader))
+        armc, _ = dict_to_armc(yaml.load(f.read(), Loader=UniqueLoader))
     armc.hdf5_file = hdf5_file = PATH / 'test.hdf5'
 
     kappa = 5
@@ -192,7 +193,7 @@ def test_from_hdf5():
     """Test :meth:`FOX.io.hdf5_utils.from_hdf5`."""
     yaml_file = PATH / 'armc.yaml'
     with open(yaml_file, 'r') as f:
-        armc, _ = dict_to_armc(yaml.load(f.read(), Loader=yaml.FullLoader))
+        armc, _ = dict_to_armc(yaml.load(f.read(), Loader=UniqueLoader))
     armc.hdf5_file = hdf5_file = PATH / 'test.hdf5'
 
     kappa = 0

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,0 +1,22 @@
+"""A module with yaml-related tests."""
+
+import yaml
+from yaml.constructor import ConstructorError
+
+from FOX.yaml import UniqueLoader
+from assertionlib import assertion
+
+YAML1 = 'a: True'
+YAML2 = 'a: False\na: True'
+
+
+def test_yaml() -> None:
+    """Tests for :class:`FOX.yaml.UniqueLoader`."""
+    dct1 = yaml.load(YAML1, Loader=yaml.Loader)
+    dct2 = yaml.load(YAML1, Loader=UniqueLoader)
+    dct3 = yaml.load(YAML2, Loader=yaml.Loader)
+
+    assertion.eq(dct1, dct2)
+    assertion.eq(dct1, dct3)
+
+    assertion.assert_(yaml.load, YAML2, Loader=UniqueLoader, exception=ConstructorError)


### PR DESCRIPTION
Closes https://github.com/nlesc-nano/auto-FOX/issues/170.

Pinging @felipeZ as this problem affects _all_ yaml files loaded with `pyyaml`; not just those in Auto-FOX.