### PR TITLE
REL: Auto-FOX 0.8.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,24 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+0.8.10
+******
+* Reorganized the dataframes in ``FOX.armc.ParamMapping``.
+* Added the ``pes_validation`` keyword. Used for constructing a set
+  of PES descriptors for the purpose of validation.
+* Dissallow the specification of duplicate .yaml keys.
+* Allow users to provide unique settings for each molecule in PES-averaged ARMC.
+* Added tests using CP2K, python 3.9, pre-releases and the minimum supported version
+  of dependencies.
+* Removed the plotting and .csv-related entry points.
+* Added the ``param.validation.enforce_constraints`` keyword; used for checking
+  whether or not initially supplied parameters satisfy all user-provided constraints.
+* Added the ``unit`` field to the ``param_metadata`` dataset.
+* Added the new ``pes.block.ref`` keyword; used for constructing PES descriptors
+  from ``qmflows.Result`` objects rather than the ``FOX.MultiMolecule`` instances
+  constructed therefrom.
+
+
 0.8.9
 *****
 * Fixed an issue where frozen parameters were not respected when performing

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.8.9'
+__version__ = '0.8.10'

--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,9 @@
     :target: https://docs.python.org/3.8/
 
 
-#################################################
-Automated Forcefield Optimization Extension 0.8.9
-#################################################
+##################################################
+Automated Forcefield Optimization Extension 0.8.10
+##################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and
 using the resulting PES descriptors for constructing forcefield parameters.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = f'{_year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.8.9'  # The full version, including alpha/beta/rc tags.
+release = '0.8.10'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 


### PR DESCRIPTION
* Reorganized the dataframes in ``FOX.armc.ParamMapping``.
* Added the ``pes_validation`` keyword. Used for constructing a set of PES descriptors for the purpose of validation.
* Dissallow the specification of duplicate .yaml keys.
* Allow users to provide unique settings for each molecule in PES-averaged ARMC.
* Added tests using CP2K, python 3.9, pre-releases and the minimum supported version of dependencies.
* Removed the plotting and .csv-related entry points.
* Added the ``param.validation.enforce_constraints`` keyword; used for checking whether or not initially supplied parameters satisfy all user-provided constraints.
* Added the ``unit`` field to the ``param_metadata`` dataset.
* Added the new ``pes.block.ref`` keyword; used for constructing PES descriptors from ``qmflows.Result`` objects rather than the ``FOX.MultiMolecule`` instances constructed therefrom.