### PR TITLE
ENH: Grab the cell parameters from previous jobs when possible

### DIFF
--- a/FOX/armc/package_manager.py
+++ b/FOX/armc/package_manager.py
@@ -416,7 +416,7 @@ class PackageManager(PackageManagerABC):
         """Create a list of MultiMolecule from the passed **results**."""
         mol_list = []
         results_list = list(results)
-        for result in results:
+        for result in results_list:
             try:  # Construct and return a MultiMolecule object
                 path: str = get_xyz_path(result.archive['work_dir'])  # type: ignore
                 mol = MultiMolecule.from_xyz(path)

--- a/tests/test_files/armc_cp2k.yaml
+++ b/tests/test_files/armc_cp2k.yaml
@@ -64,12 +64,34 @@ job:
     type: FOX.armc.PackageManager
     molecule: tests/test_files/Cd68Se55_26COO_MD_trajec.xyz
 
+    cell_opt:
+        type: qmflows.cp2k_mm
+        template: qmflows.geometry.specific.cp2k_mm
+        settings:
+            prm: tests/test_files/ligand.prm
+            cell_parameters: [50, 50, 50]
+            input:
+                force_eval:
+                    stress_tensor: analytical
+                    mm:
+                        forcefield:
+                            spline:
+                                emax_spline: 500.0
+                                r0_nb: 0.1
+                motion:
+                    print:
+                        cell on:
+                            filename: ''
+                    cell_opt:
+                        max_iter: 10
+                        optimizer: lbfgs
+                global:
+                    run_type: cell_opt
     md:
         type: qmflows.cp2k_mm
         template: qmflows.md.specific.cp2k_mm
         settings:
             prm: tests/test_files/ligand.prm
-            cell_parameters: [50, 50, 50]
             input:
                 force_eval:
                     mm:

--- a/tests/test_files/armcpt_cp2k.yaml
+++ b/tests/test_files/armcpt_cp2k.yaml
@@ -69,12 +69,34 @@ job:
     type: FOX.armc.PackageManager
     molecule: tests/test_files/Cd68Se55_26COO_MD_trajec.xyz
 
+    cell_opt:
+        type: qmflows.cp2k_mm
+        template: qmflows.geometry.specific.cp2k_mm
+        settings:
+            prm: tests/test_files/ligand.prm
+            cell_parameters: [50, 50, 50]
+            input:
+                force_eval:
+                    stress_tensor: analytical
+                    mm:
+                        forcefield:
+                            spline:
+                                emax_spline: 500.0
+                                r0_nb: 0.1
+                motion:
+                    print:
+                        cell on:
+                            filename: ''
+                    cell_opt:
+                        max_iter: 10
+                        optimizer: lbfgs
+                global:
+                    run_type: cell_opt
     md:
         type: qmflows.cp2k_mm
         template: qmflows.md.specific.cp2k_mm
         settings:
             prm: tests/test_files/ligand.prm
-            cell_parameters: [50, 50, 50]
             input:
                 force_eval:
                     mm:


### PR DESCRIPTION
For example, if a MD calculation is preceded by a cell optimization then the new cell parameters are now automatically transfered to the MD.
Xref https://github.com/SCM-NV/qmflows/pull/237.