### PR TITLE
BUG: Check if `results is not None` before iterating through it

### DIFF
--- a/FOX/armc/package_manager.py
+++ b/FOX/armc/package_manager.py
@@ -411,9 +411,13 @@ class PackageManager(PackageManagerABC):
 
     @staticmethod
     def _extract_mol(
-        results: Iterable[Result], logger: Logger
+        results: Optional[Iterable[Result]], logger: Logger
     ) -> Union[Tuple[None, None], Tuple[List[MultiMolecule], List[Any]]]:
         """Create a list of MultiMolecule from the passed **results**."""
+        # `noodles.run_parallel()` can return `None` under certain circumstances
+        if results is None:
+            return None, None
+
         mol_list = []
         results_list = list(results)
         for result in results_list:


### PR DESCRIPTION
There are apparently conditions wherein `noodles.run_parallel()` can straight up return `None`.