### PR TITLE
REL: Auto-FOX 0.8.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+0.8.11
+******
+* Fixed an issue where the .hdf5 status would not be properly cleared (if necessary).
+* Grab the cell parameters from previous jobs if applicable.
+* More thouroughly check the ``qmflows.Result`` status before accessing it.
+* Automatically determine appropiate chunk sizes when calculating the RDF.
+* Added a new sub-module dedicated to the calculation of properties: ``FOX.properties``.
+* Fixed an issue where parsing the ``unit`` would fail when parameter guessing.
+* Fixed an issue where writing ``nan`` to ``armc.xyz.hdf5`` would fail.
+
+
 0.8.10
 ******
 * Reorganized the dataframes in ``FOX.armc.ParamMapping``.

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.8.10'
+__version__ = '0.8.11'

--- a/FOX/properties/base.py
+++ b/FOX/properties/base.py
@@ -303,7 +303,8 @@ def get_attr(obj, name, default=_NULL, reduce=None, axis=None):
     """
     if default is _NULL:
         ret = getattr(obj, name)
-    ret = getattr(obj, name, default)
+    else:
+        ret = getattr(obj, name, default)
     return FromResult._reduce(ret, reduce, axis)
 
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
 
 
 ##################################################
-Automated Forcefield Optimization Extension 0.8.10
+Automated Forcefield Optimization Extension 0.8.11
 ##################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = f'{_year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.8.10'  # The full version, including alpha/beta/rc tags.
+release = '0.8.11'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 


### PR DESCRIPTION
* Fixed an issue where the .hdf5 status would not be properly cleared (if necessary).
* Grab the cell parameters from previous jobs if applicable.
* More thoroughly check the ``qmflows.Result`` status before accessing it.
* Automatically determine appropriate chunk sizes when calculating the RDF.
* Added a new sub-module dedicated to the calculation of properties: ``FOX.properties``.
* Fixed an issue where parsing the ``unit`` would fail when parameter guessing.
* Fixed an issue where writing ``nan`` to ``armc.xyz.hdf5`` would fail.