### PR TITLE
ENH: Add a furthest-point-based reductor to the `similarity` recipe

### DIFF
--- a/FOX/recipes/__init__.py
+++ b/FOX/recipes/__init__.py
@@ -4,12 +4,12 @@ from .param import get_best, overlay_descriptor, plot_descriptor
 from .psf import generate_psf, generate_psf2, extract_ligand
 from .ligands import get_lig_center, get_multi_lig_center
 from .time_resolution import time_resolved_adf, time_resolved_rdf
-from .similarity import compare_trajectories
+from .similarity import compare_trajectories, fps_reduce
 
 __all__ = [
     'get_best', 'overlay_descriptor', 'plot_descriptor',
     'generate_psf', 'generate_psf2', 'extract_ligand',
     'get_lig_center', 'get_multi_lig_center',
     'time_resolved_adf', 'time_resolved_rdf',
-    'compare_trajectories',
+    'compare_trajectories', 'fps_reduce',
 ]

--- a/FOX/recipes/similarity.pyi
+++ b/FOX/recipes/similarity.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Union, Callable, overload, TypeVar
+from typing import Any, Union, Callable, overload, TypeVar, Iterable
 
 from FOX import MultiMolecule
 import numpy as np
@@ -93,3 +93,14 @@ def compare_trajectories(
     reset_origin: bool = True,
     **kwargs: Any,
 ) -> _NDArray[_SCT2]: ...
+
+def fps_reduce(
+    dist_mat: _NDArray[np.number[Any] | np.bool_ | np.character | np.object_],
+    n: None | int = ...,
+    *,
+    operation: Literal["min", "max"] = ...,
+    cluster_size: int | Iterable[int] = ...,
+    start: None | int = ...,
+    randomness: None | float = ...,
+    weight: Callable[[np.ndarray], np.ndarray] = ...,
+) -> _NDArray[np.intp]: ...

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ tests_require = [
     'pydocstyle',
     'auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.6',
     'ase',
+    'CAT@git+https://github.com/nlesc-nano/CAT@master',
 ]
 tests_require += docs_require
 


### PR DESCRIPTION
Note that this new function requires installation of https://github.com/nlesc-nano/CAT.

xref https://github.com/nlesc-nano/auto-FOX/issues/206.