### PR TITLE
REL: Auto-FOX 0.8.12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+0.8.12
+******
+* Added a recipe for calculating the similarity between 2 MD trajectories.
+* Added improved support for custom atom types.
+* Made the ligand optional in the ``FOX.recipes.generate_psf()`` recipe.
+* Fixed an issue where non-absolute distances were used when calculating the pressure.
+* Fixed an issue where non-charge parameters were updated incorrectly.
+* Fixed an issue where parameter guessing could fail if no ``.prm`` file was provided.
+
+
 0.8.11
 ******
 * Fixed an issue where the .hdf5 status would not be properly cleared (if necessary).

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.8.11'
+__version__ = '0.8.12'

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
 
 
 ##################################################
-Automated Forcefield Optimization Extension 0.8.11
+Automated Forcefield Optimization Extension 0.8.12
 ##################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = f'{_year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.8.11'  # The full version, including alpha/beta/rc tags.
+release = '0.8.12'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 


### PR DESCRIPTION
* Added a recipe for calculating the similarity between 2 MD trajectories.
* Added improved support for custom atom types.
* Made the ligand optional in the ``FOX.recipes.generate_psf()`` recipe.
* Fixed an issue where non-absolute distances were used when calculating the pressure.
* Fixed an issue where non-charge parameters were updated incorrectly.
* Fixed an issue where parameter guessing could fail if no ``.prm`` file was provided.