### PR TITLE
REL: Auto-FOX 0.9.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+0.9.0
+*****
+* Fixed an issue wherein `PSFContainer.to_atom_alias_dict` would assign incorrect indices to atom aliases.
+* Fixed an issue wherein treating an entire ARMC parameter block as frozen could raise.
+* Added the `FOX.MultiMolecule.lattice` property for storing the lattice vectors of periodic systems.
+* Added `FOX.io.lattice_from_cell`, a function for reading lattice vectors from CP2K .cell files.
+* Added support for periodic ADF and RDF calculations.
+* Added the new `job.lattice` keyword to the ARMC workflow for specifying lattice vectors of the reference system.
+* Lattice vectors are now preserved when interconverting between PLAMS, ASE and Auto-FOX.
+* Read the pressure from the CP2K .out file when calculating the bulk modulus, rather than calculating it from scratch.
+
+
 0.8.12
 ******
 * Added a recipe for calculating the similarity between 2 MD trajectories.

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.8.12'
+__version__ = '0.9.0'

--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,9 @@
     :target: https://docs.python.org/3.8/
 
 
-##################################################
-Automated Forcefield Optimization Extension 0.8.12
-##################################################
+#################################################
+Automated Forcefield Optimization Extension 0.9.0
+#################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and
 using the resulting PES descriptors for constructing forcefield parameters.
@@ -92,7 +92,7 @@ Installing **Auto-FOX**
 
 - If using Conda, enable the environment: ``conda activate FOX``
 
-- Install **Auto-FOX** with PyPi: ``pip install git+https://github.com/nlesc-nano/auto-FOX@0.8 --upgrade``
+- Install **Auto-FOX** with PyPi: ``pip install git+https://github.com/nlesc-nano/auto-FOX@0.9 --upgrade``
 
 - Congratulations, **Auto-FOX** is now installed and ready for use!
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = f'{_year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.8.12'  # The full version, including alpha/beta/rc tags.
+release = '0.9.0'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 


### PR DESCRIPTION
Auto-FOX 0.9.0
---------------
* Fixed an issue wherein `PSFContainer.to_atom_alias_dict` would assign incorrect indices to atom aliases.
* Fixed an issue wherein treating an entire ARMC parameter block as frozen could raise.
* Added the `FOX.MultiMolecule.lattice` property for storing the lattice vectors of periodic systems.
* Added `FOX.io.lattice_from_cell`, a function for reading lattice vectors from CP2K .cell files.
* Added support for periodic ADF and RDF calculations.
* Added the new `job.lattice` keyword to the ARMC workflow for specifying lattice vectors of the reference system.
* Lattice vectors are now preserved when interconverting between PLAMS, ASE and Auto-FOX.
* Read the pressure from the CP2K .out file when calculating the bulk modulus, rather than calculating it from scratch.
