### PR TITLE
MAINT: Write the super-/sub-iteration after updating all other datasets

### DIFF
--- a/FOX/io/hdf5_utils.py
+++ b/FOX/io/hdf5_utils.py
@@ -431,8 +431,6 @@ def to_hdf5(filename: PathType, dset_dict: Mapping[str, np.ndarray],
 
     # Update the hdf5 file
     with h5py.File(filename, 'r+', libver='latest') as f:
-        f.attrs['super-iteration'] = kappa
-        f.attrs['sub-iteration'] = omega
         for key, value in dset_dict.items():
             try:
                 if key == 'xyz':
@@ -445,6 +443,8 @@ def to_hdf5(filename: PathType, dset_dict: Mapping[str, np.ndarray],
                     dset[kappa, omega] = np.asarray(value, dtype=dset.dtype)
             except Exception as ex:
                 raise RuntimeError(f'Failed to write dataset {key!r}') from ex
+        f.attrs['super-iteration'] = kappa
+        f.attrs['sub-iteration'] = omega
 
     # Update the second hdf5 file with Cartesian coordinates
     filename_xyz = _get_filename_xyz(filename)

--- a/FOX/recipes/param.py
+++ b/FOX/recipes/param.py
@@ -243,7 +243,6 @@ def overlay_descriptor(hdf5_file: Union[str, 'PathLike[str]'], name: str = 'rdf'
     j: int = aux_error.sum(axis=1, skipna=False).idxmin()
     logger.debug(f"Optimum ARMC cycle: {np.unravel_index(j, shape)}")
     mm = mm[j]
-    qm = qm[0]
 
     ret = {}
     for key in mm:

--- a/tests/test_ligands_recipe.py
+++ b/tests/test_ligands_recipe.py
@@ -15,7 +15,7 @@ HDF5 = Path('tests') / 'test_files' / 'armc_test.hdf5'
 
 def test_get_best() -> None:
     """Test :func:`FOX.recipes.param.get_best`."""
-    keys = ('aux_error', 'aux_error_mod', 'param', 'phi', 'rdf')
+    keys = ('aux_error', 'aux_error_mod', 'param', 'rdf')
 
     for name in keys:
         ref = np.load(PATH / f'{name}.npy')


### PR DESCRIPTION
The changes introduced herein should reduce any .hdf5-corruption-related issues that might be caused by forcefully terminating ARMC in the middle of a write operation.

The problem is resolved via the following two countermeasures:
* Only read data from the .hdf5 file up to and including the current iteration.
* Update the super-/sub-iteration _after_ updating all the datasets.