### PR TITLE
ENH: Store metadata and net charges for each individual system in PES-averaged ARMC and ARMCPT

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -79,7 +79,7 @@ jobs:
             -   name: Install dependencies (minimum version)
                 if: matrix.special == '; minimum version'
                 run: |
-                    conda create -n test -c conda-forge python=${{ matrix.version }} pyyaml=5.1 rdkit=2018.09 numpy=1.15 h5py=2.10 pandas=0.23 scipy=1.2.0 matplotlib=3.0
+                    conda create -n test -c conda-forge python=${{ matrix.version }} pyyaml=5.1 rdkit=2018.09 numpy=1.15 h5py=2.10 pandas=0.24 scipy=1.2.0 matplotlib=3.0
                     source $CONDA/bin/activate test
                     pip install Nano-Utils==1.2.1 schema==0.7.1 AssertionLib==2.2 noodles==0.3.3 sphinx==2.4 sphinx_rtd_theme==0.3.0
                     pip install -e .[test]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ ignore =
     E704
     E731
     W504
+    E721
     FOX/examples/ ALL
     FOX/properties/*.pyi ALL
 max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = [
     'pytest-cov',
     'flake8',
     'pydocstyle',
-    'auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.7',
+    'auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.8',
     'ase',
     'CAT@git+https://github.com/nlesc-nano/CAT@master',
 ]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = [
     'pytest-cov',
     'flake8',
     'pydocstyle',
-    'auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.6',
+    'auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.7',
     'ase',
     'CAT@git+https://github.com/nlesc-nano/CAT@master',
 ]

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
         'pyyaml>=5.1',
         'numpy>=1.15',
         'scipy>=1.2',
-        'pandas',
+        'pandas>=0.24',
         'schema>=0.7.1',
         'AssertionLib>=2.3',
         'noodles>=0.3.3',

--- a/tests/test_hdf5_utils.py
+++ b/tests/test_hdf5_utils.py
@@ -38,7 +38,7 @@ def test_create_hdf5():
     ref_dict['/aux_error_mod'].dtype = np.float64
     ref_dict['/param'].shape = 500, 100, 1, 15
     ref_dict['/param'].dtype = np.float64
-    ref_dict['/param_metadata'].shape = (15,)
+    ref_dict['/param_metadata'].shape = (1, 15)
     ref_dict['/param_metadata'].dtype = np.void
     ref_dict['/phi'].shape = 500, 1
     ref_dict['/phi'].dtype = np.float64
@@ -99,6 +99,40 @@ def test_to_hdf5():
 
 
 PARAM_METADATA = pd.DataFrame.from_dict({
+    'min': {
+        ('charge', 'charge', 'CG2O3'): -inf,
+        ('charge', 'charge', 'Cd'): 0.5,
+        ('charge', 'charge', 'HGR52'): -inf,
+        ('charge', 'charge', 'OG2D2'): -inf,
+        ('charge', 'charge', 'Se'): -inf,
+        ('lennard_jones', 'epsilon', 'Cd Cd'): -inf,
+        ('lennard_jones', 'epsilon', 'Cd OG2D2'): -inf,
+        ('lennard_jones', 'epsilon', 'Cd Se'): -inf,
+        ('lennard_jones', 'epsilon', 'OG2D2 Se'): -inf,
+        ('lennard_jones', 'epsilon', 'Se Se'): -inf,
+        ('lennard_jones', 'sigma', 'Cd Cd'): -inf,
+        ('lennard_jones', 'sigma', 'Cd OG2D2'): -inf,
+        ('lennard_jones', 'sigma', 'Cd Se'): -inf,
+        ('lennard_jones', 'sigma', 'OG2D2 Se'): -inf,
+        ('lennard_jones', 'sigma', 'Se Se'): -inf,
+    },
+    'max': {
+        ('charge', 'charge', 'CG2O3'): inf,
+        ('charge', 'charge', 'Cd'): 1.5,
+        ('charge', 'charge', 'HGR52'): inf,
+        ('charge', 'charge', 'OG2D2'): 0.0,
+        ('charge', 'charge', 'Se'): -0.5,
+        ('lennard_jones', 'epsilon', 'Cd Cd'): inf,
+        ('lennard_jones', 'epsilon', 'Cd OG2D2'): inf,
+        ('lennard_jones', 'epsilon', 'Cd Se'): inf,
+        ('lennard_jones', 'epsilon', 'OG2D2 Se'): inf,
+        ('lennard_jones', 'epsilon', 'Se Se'): inf,
+        ('lennard_jones', 'sigma', 'Cd Cd'): inf,
+        ('lennard_jones', 'sigma', 'Cd OG2D2'): inf,
+        ('lennard_jones', 'sigma', 'Cd Se'): inf,
+        ('lennard_jones', 'sigma', 'OG2D2 Se'): inf,
+        ('lennard_jones', 'sigma', 'Se Se'): inf,
+    },
     'count': {
         ('charge', 'charge', 'CG2O3'): 26,
         ('charge', 'charge', 'Cd'): 68,
@@ -150,40 +184,6 @@ PARAM_METADATA = pd.DataFrame.from_dict({
         ('lennard_jones', 'sigma', 'OG2D2 Se'): False,
         ('lennard_jones', 'sigma', 'Se Se'): False,
     },
-    'max': {
-        ('charge', 'charge', 'CG2O3'): inf,
-        ('charge', 'charge', 'Cd'): 1.5,
-        ('charge', 'charge', 'HGR52'): inf,
-        ('charge', 'charge', 'OG2D2'): 0.0,
-        ('charge', 'charge', 'Se'): -0.5,
-        ('lennard_jones', 'epsilon', 'Cd Cd'): inf,
-        ('lennard_jones', 'epsilon', 'Cd OG2D2'): inf,
-        ('lennard_jones', 'epsilon', 'Cd Se'): inf,
-        ('lennard_jones', 'epsilon', 'OG2D2 Se'): inf,
-        ('lennard_jones', 'epsilon', 'Se Se'): inf,
-        ('lennard_jones', 'sigma', 'Cd Cd'): inf,
-        ('lennard_jones', 'sigma', 'Cd OG2D2'): inf,
-        ('lennard_jones', 'sigma', 'Cd Se'): inf,
-        ('lennard_jones', 'sigma', 'OG2D2 Se'): inf,
-        ('lennard_jones', 'sigma', 'Se Se'): inf,
-    },
-    'min': {
-        ('charge', 'charge', 'CG2O3'): -inf,
-        ('charge', 'charge', 'Cd'): 0.5,
-        ('charge', 'charge', 'HGR52'): -inf,
-        ('charge', 'charge', 'OG2D2'): -inf,
-        ('charge', 'charge', 'Se'): -inf,
-        ('lennard_jones', 'epsilon', 'Cd Cd'): -inf,
-        ('lennard_jones', 'epsilon', 'Cd OG2D2'): -inf,
-        ('lennard_jones', 'epsilon', 'Cd Se'): -inf,
-        ('lennard_jones', 'epsilon', 'OG2D2 Se'): -inf,
-        ('lennard_jones', 'epsilon', 'Se Se'): -inf,
-        ('lennard_jones', 'sigma', 'Cd Cd'): -inf,
-        ('lennard_jones', 'sigma', 'Cd OG2D2'): -inf,
-        ('lennard_jones', 'sigma', 'Cd Se'): -inf,
-        ('lennard_jones', 'sigma', 'OG2D2 Se'): -inf,
-        ('lennard_jones', 'sigma', 'Se Se'): -inf,
-    },
     'unit': {
         ('charge', 'charge', 'CG2O3'): '',
         ('charge', 'charge', 'Cd'): '',
@@ -200,8 +200,9 @@ PARAM_METADATA = pd.DataFrame.from_dict({
         ('lennard_jones', 'sigma', 'Cd Se'): 'nm',
         ('lennard_jones', 'sigma', 'OG2D2 Se'): 'nm',
         ('lennard_jones', 'sigma', 'Se Se'): 'nm',
-    }
+    },
 })
+PARAM_METADATA.columns = pd.MultiIndex.from_tuples([(0, k) for k in PARAM_METADATA.columns])
 
 
 @delete_finally(PATH / 'test.hdf5', PATH / 'test.xyz.hdf5')

--- a/tests/test_param_mapping.py
+++ b/tests/test_param_mapping.py
@@ -37,7 +37,7 @@ PARAM = ParamMapping(_DF, constraints=_CONSTRAINTS)
 def test_call():
     """Test :meth:`ParamMapping.__call__`."""
     param = PARAM.copy(deep=True)
-    ref = sum(param.param.loc['charge', 0] * param.metadata.loc['charge', 'count'])
+    ref = sum(param.param.loc['charge', 0] * param.metadata.loc['charge', (0, 'count')])
 
     failed_iterations = []
     for i in range(1000):
@@ -46,20 +46,20 @@ def test_call():
             failed_iterations.append(i)
             ex_backup = ex
 
-        value = sum(param.param.loc['charge', 0] * param.metadata.loc['charge', 'count'])
+        value = sum(param.param.loc['charge', 0] * param.metadata.loc['charge', (0, 'count')])
         assertion.isclose(value, ref, abs_tol=0.001)
 
         try:
-            assertion.le(param.param[0], param.metadata['max'], post_process=np.all)
+            assertion.le(param.param[0], param.metadata[0, 'max'], post_process=np.all)
         except AssertionError as ex:
-            df = pd.DataFrame({'param': param.param[0], 'max': param.metadata['max']})
+            df = pd.DataFrame({'param': param.param[0], 'max': param.metadata[0, 'max']})
             msg = f"iteration{i}\n{df.round(2)}"
             raise AssertionError(msg) from ex
 
         try:
-            assertion.ge(param.param[0], param.metadata['min'], post_process=np.all)
+            assertion.ge(param.param[0], param.metadata[0, 'min'], post_process=np.all)
         except AssertionError as ex:
-            df = pd.DataFrame({'param': param.param[0], 'max': param.metadata['min']})
+            df = pd.DataFrame({'param': param.param[0], 'max': param.metadata[0, 'min']})
             msg = f"iteration{i}\n{df.round(2)}"
             raise AssertionError(msg) from ex
 


### PR DESCRIPTION
Adds the capability to `ParamMapping` to store net charges and parameter metadata for multiple systems.

First in a series of PRs for fixing an issue with PES-averaged ARMC where the charges aren't properly conserved.