### PR TITLE
REL: Auto-FOX 0.9.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+0.9.1
+*****
+* Added the new ``segment_dict`` parameter to the ``PSFContainer.generate_x()`` functions.
+* Added the new ``PSFContainer.sort_values`` method.
+* Store metadata and net charges for each individual system in PES-averaged ARMC and ARMCPT.
+* Fixed an issue wherein frozen atomic charges were ignored when not explicitly specified.
+* Fixed in issue wherein PSFContainer.sort_values did not not update the residue ID.
+* Fixed an issue wherein guessed parameters could overwrite ones that were explicitly specified.
+* Fixed an issue wherein frozen parameters weren't properly sorted.
+* Fixed an issue wherein the mean pair-density was computed using lattice vectors in non-periodic calculations.
+
+
 0.9.0
 *****
 * Fixed an issue wherein `PSFContainer.to_atom_alias_dict` would assign incorrect indices to atom aliases.

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'

--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,11 @@
     :target: https://docs.python.org/3.7/
 .. image:: https://img.shields.io/badge/python-3.8-blue.svg
     :target: https://docs.python.org/3.8/
-
+.. image:: https://img.shields.io/badge/python-3.9-blue.svg
+    :target: https://docs.python.org/3.9/
 
 #################################################
-Automated Forcefield Optimization Extension 0.9.0
+Automated Forcefield Optimization Extension 0.9.1
 #################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = f'{_year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.9.0'  # The full version, including alpha/beta/rc tags.
+release = '0.9.1'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 


### PR DESCRIPTION
* Added the new ``segment_dict`` parameter to the ``PSFContainer.generate_x()`` functions.
* Added the new ``PSFContainer.sort_values`` method.
* Store metadata and net charges for each individual system in PES-averaged ARMC and ARMCPT.
* Fixed an issue wherein frozen atomic charges were ignored when not explicitly specified.
* Fixed in issue wherein PSFContainer.sort_values did not not update the residue ID.
* Fixed an issue wherein guessed parameters could overwrite ones that were explicitly specified.
* Fixed an issue wherein frozen parameters weren't properly sorted.
* Fixed an issue wherein the mean pair-density was computed using lattice vectors in non-periodic calculations.