### PR TITLE
 BUG: Fixed an issue wherein init_power_spectrum could raise when the atom subset is specified

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -88,7 +88,7 @@ jobs:
                 run: |
                     source $CONDA/bin/activate test
                     export CP2K_DATA_DIR="/usr/share/cp2k"
-                    pytest -m "not slow" -v
+                    pytest -m "not slow"
 
             -   name: Run codecov
                 uses: codecov/codecov-action@v1

--- a/FOX/classes/multi_mol.py
+++ b/FOX/classes/multi_mol.py
@@ -1558,9 +1558,13 @@ class MultiMolecule(_MultiMolecule):
 
     """####################################  Power spectrum  ###################################"""
 
-    def init_power_spectrum(self, mol_subset: MolSubset = None,
-                            atom_subset: AtomSubset = None,
-                            freq_max: int = 4000) -> pd.DataFrame:
+    def init_power_spectrum(
+        self,
+        mol_subset: MolSubset = None,
+        atom_subset: AtomSubset = None,
+        freq_max: int = 4000,
+        timestep: float = 1,
+    ) -> pd.DataFrame:
         """Calculate and return the power spectrum associated with this instance.
 
         Parameters
@@ -1575,6 +1579,8 @@ class MultiMolecule(_MultiMolecule):
             Include all :math:`n` atoms per molecule in this instance if :data:`None`.
         freq_max : :class:`int`
             The maximum to be returned wavenumber (cm**-1).
+        timestep : :class:`float`
+            The stepsize, in femtoseconds, between subsequent frames.
 
         Returns
         -------
@@ -1603,8 +1609,12 @@ class MultiMolecule(_MultiMolecule):
 
         return df
 
-    def get_vacf(self, mol_subset: MolSubset = None,
-                 atom_subset: AtomSubset = None) -> np.ndarray:
+    def get_vacf(
+        self,
+        mol_subset: MolSubset = None,
+        atom_subset: AtomSubset = None,
+        timestep: float = 1,
+    ) -> np.ndarray:
         """Calculate and return the velocity autocorrelation function (VACF).
 
         Parameters
@@ -1617,6 +1627,8 @@ class MultiMolecule(_MultiMolecule):
             Perform the calculation on a subset of atoms in this instance, as
             determined by their atomic index or atomic symbol.
             Include all :math:`n` atoms per molecule in this instance if :data:`None`.
+        timestep : :class:`float`
+            The stepsize, in femtoseconds, between subsequent frames.
 
         Returns
         -------
@@ -1628,7 +1640,9 @@ class MultiMolecule(_MultiMolecule):
         from scipy.signal import fftconvolve
 
         # Get atomic velocities
-        v = self.get_velocity(1e-15, mol_subset=mol_subset, atom_subset=atom_subset)  # A / s
+        v = self.get_velocity(  # A / s
+            timestep * 1e-15, mol_subset=mol_subset, atom_subset=atom_subset
+        )
 
         # Construct the velocity autocorrelation function
         vacf = fftconvolve(v, v[::-1], axes=0)[len(v)-1:]

--- a/FOX/classes/multi_mol.py
+++ b/FOX/classes/multi_mol.py
@@ -1699,6 +1699,8 @@ class MultiMolecule(_MultiMolecule):
             return [(atom_subset, self.atoms[atom_subset])]
         elif isinstance(atom_subset, int):
             return [(False, (atom_subset,))]
+        elif len(atom_subset) == 0:
+            return []
         elif isinstance(atom_subset[0], (int, np.integer)):
             return enumerate(atom_subset)
         elif isinstance(atom_subset[0], str):
@@ -1895,7 +1897,11 @@ class MultiMolecule(_MultiMolecule):
                 return slice(atom_subset.start, atom_subset.stop, atom_subset.step)
 
         ret = np.array(atom_subset, ndmin=1, copy=False).ravel()
-        i = ret[0]
+        try:
+            i = ret[0]
+        except IndexError:  # Empty sequence
+            return np.empty((0,), dtype=np.intp)
+
         if isinstance(i, np.str_):
             return np.concatenate([self._atoms_get(j) for j in ret]).astype(np.intp, copy=False)
         elif isinstance(i, np.integer):


### PR DESCRIPTION
In addition, this PR exposes the `timestep` keyword to `MultiMolecule.get_vacf()` and `MultiMolecule.init_power_spectrum()`.