### PR TITLE
BUG: Fixed an issue wherein auto-FOX would not check the status of jobs

### DIFF
--- a/FOX/armc/package_manager.py
+++ b/FOX/armc/package_manager.py
@@ -434,6 +434,9 @@ class PackageManager(PackageManagerABC):
         mol_list = []
         results_list = list(results)
         for result in results_list:
+            if result.status in {'failed', 'crashed'}:
+                return None, None
+
             try:
                 lattice: None | np.ndarray[Any, np.dtype[np.float64]] = result.lattice
                 assert lattice is not None


### PR DESCRIPTION
Previously, Auto-FOX would allow jobs that crashed halfway through to be used for constructing PES descriptors.
These will jobs will now be treated as crashed and ignored.