### PR TITLE
ENH: Add error functions based on non-mse errors

### DIFF
--- a/FOX/armc/__init__.py
+++ b/FOX/armc/__init__.py
@@ -16,6 +16,8 @@ from .err_funcs import (
     mse_normalized_max,
     mse_normalized_v2,
     mse_normalized_weighted_v2,
+    err_normalized,
+    err_normalized_weighted,
 )
 
 __all__ = [
@@ -27,5 +29,5 @@ __all__ = [
     'PackageManager', 'PackageManagerABC',
     'ParamMapping', 'ParamMappingABC',
     'default_error_func', 'mse_normalized', 'mse_normalized_weighted', 'mse_normalized_max',
-    'mse_normalized_v2', 'mse_normalized_weighted_v2',
+    'mse_normalized_v2', 'mse_normalized_weighted_v2', 'err_normalized', 'err_normalized_weighted',
 ]


### PR DESCRIPTION
Error functions based on the mean, rather than the mean squared: 
* `FOX.armc.err_normalized`
* `FOX.armc.err_normalized_weighted`