### PR TITLE
REL: Release Auto-FOX 0.10.0

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,34 @@
+name: Publish
+
+on:
+    release:
+        types: [published, edited]
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   name: Set up Python
+                uses: actions/setup-python@v2
+
+            -   name: Install dependencies
+                run: pip install wheel twine
+
+            -   name: Python info
+                run: |
+                    which python
+                    python --version
+
+            -   name: Installed packages
+                run: pip list
+
+            -   name: Build the package
+                run: python setup.py sdist bdist_wheel
+
+            -   name: Publish the package
+                uses: pypa/gh-action-pypi-publish@master
+                with:
+                    user: __token__
+                    password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -84,6 +84,7 @@ jobs:
                     else
                         pip install -e .[test_no_optional]
                     fi
+                    pip install auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.8
 
             -   name: Info Python
                 shell: bash

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,20 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+0.10.0
+******
+* Add a new ``MultiMolecule`` method for constructing supercells.
+* Add a timestep parameter to ``MultiMolecule.init_power_spectrum``.
+* Fixed an issue wherein ``init_power_spectrum`` could raise when the atom subset is specified.
+* Raise a ``ValueError`` if an atom type with multiple charges is found.
+* Fixed an issue wherein net charges weren't properly conserved in PES-averaged ARMC.
+* Allow users to pass custom error functions.
+* Make rdkit an optional dependency.
+* Fixed an issue wherein auto-FOX would not check the status of jobs.
+* Add the new atom_pairs keyword to init_rdf and init_adf.
+* Round the net charge to the nearest integer.
+
+
 0.9.1
 *****
 * Added the new ``segment_dict`` parameter to the ``PSFContainer.generate_x()`` functions.

--- a/FOX/__version__.py
+++ b/FOX/__version__.py
@@ -1,3 +1,3 @@
 """The Auto-FOX version."""
 
-__version__ = '0.9.1'
+__version__ = '0.10.0'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include LICENSE
-include README.rst

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Installing **Auto-FOX**
 
 - If using Conda, enable the environment: ``conda activate FOX``
 
-- Install **Auto-FOX** with PyPi: ``pip install git+https://github.com/nlesc-nano/auto-FOX@0.9 --upgrade``
+- Install **Auto-FOX** with PyPi: ``pip install auto-FOX --upgrade``
 
 - Congratulations, **Auto-FOX** is now installed and ready for use!
 

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@
 .. image:: https://img.shields.io/badge/python-3.9-blue.svg
     :target: https://docs.python.org/3.9/
 
-#################################################
-Automated Forcefield Optimization Extension 0.9.1
-#################################################
+##################################################
+Automated Forcefield Optimization Extension 0.10.0
+##################################################
 
 **Auto-FOX** is a library for analyzing potential energy surfaces (PESs) and
 using the resulting PES descriptors for constructing forcefield parameters.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = f'{_year}, {author}'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-release = '0.9.1'  # The full version, including alpha/beta/rc tags.
+release = '0.10.0'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]  # The short X.Y version.
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 description_file = README.rst
+license_file = LICENSE
 
 [aliases]
 # Define `python setup.py test`

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: GNU Lesser General Public License',
+        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Natural Language :: English',
         'Operating System :: Unix',
         'Operating System :: MacOS',

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,10 @@ docs_require = [
 tests_require_no_optional = [
     'pytest>=5.4.0',
     'pytest-cov',
-    'auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.8',
 ]
 tests_require = [
     'ase>=3.21.1',
-    'CAT@git+https://github.com/nlesc-nano/CAT@master',
+    'nlesc-CAT>=0.10.0',
 ]
 tests_require += tests_require_no_optional
 tests_require += docs_require
@@ -109,7 +108,7 @@ setup(
         'AssertionLib>=2.3',
         'noodles>=0.3.3',
         'h5py>=2.10',
-        'qmflows@git+https://github.com/SCM-NV/qmflows@master',
+        'qmflows>=0.11.0',
         'plams>=1.5.1',
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -111,9 +111,6 @@ setup(
         'qmflows>=0.11.0',
         'plams>=1.5.1',
     ],
-    setup_requires=[
-        'pytest-runner'
-    ],
     tests_require=tests_require,
     extras_require={
         'docs': docs_require,


### PR DESCRIPTION
* Add a new ``MultiMolecule`` method for constructing supercells.
* Add a timestep parameter to ``MultiMolecule.init_power_spectrum``.
* Fixed an issue wherein ``init_power_spectrum`` could raise when the atom subset is specified.
* Raise a ``ValueError`` if an atom type with multiple charges is found.
* Fixed an issue wherein net charges weren't properly conserved in PES-averaged ARMC.
* Allow users to pass custom error functions.
* Make rdkit an optional dependency.
* Fixed an issue wherein auto-FOX would not check the status of jobs.
* Add the new atom_pairs keyword to init_rdf and init_adf.
* Round the net charge to the nearest integer.