### PR TITLE
BUG: Transpose the axes when returning in `get_multi_lig_center`

### DIFF
--- a/FOX/recipes/ligands.py
+++ b/FOX/recipes/ligands.py
@@ -208,7 +208,7 @@ def get_multi_lig_center(mol: MultiMolecule, idx_iter: Iterable[Sequence[int]],
             continue
 
         mass = mass_[idx][None, ..., None]
-        ligand *= mass
+        ligand = ligand * mass
         ret_append(ligand.sum(axis=1) / mass.sum(axis=1))
 
-    return np.array(ret)
+    return np.array(ret, dtype=mol.dtype).swapaxes(0, 1)


### PR DESCRIPTION
CC @RobertaPascazio 

The axes order should be `(n_mol, n_atom, 3)`, not `(n_atom, n_mol, 3)`.