### PR TITLE
ENH: Add a workflow for converting CHARMM .rtf & .prm files into GROMACS .top files

### DIFF
--- a/FOX/recipes/__init__.py
+++ b/FOX/recipes/__init__.py
@@ -5,6 +5,7 @@ from .psf import generate_psf, generate_psf2, extract_ligand
 from .ligands import get_lig_center, get_multi_lig_center
 from .time_resolution import time_resolved_adf, time_resolved_rdf
 from .similarity import compare_trajectories, fps_reduce
+from .top import create_top
 
 __all__ = [
     'get_best', 'overlay_descriptor', 'plot_descriptor',
@@ -12,4 +13,5 @@ __all__ = [
     'get_lig_center', 'get_multi_lig_center',
     'time_resolved_adf', 'time_resolved_rdf',
     'compare_trajectories', 'fps_reduce',
+    'create_top',
 ]

--- a/FOX/recipes/top.py
+++ b/FOX/recipes/top.py
@@ -1,0 +1,214 @@
+"""Recipe for creating GROMACS .top files from an .xyz and CHARMM .rtf and .str files.
+
+Index
+-----
+.. currentmodule:: FOX.recipes
+.. autosummary::
+    create_top
+
+API
+---
+.. autofunction:: create_top
+
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import math
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from scm.plams import PT
+
+import FOX
+
+if sys.version_info >= (3, 9):
+    from collections.abc import Iterator
+else:
+    from typing import Iterator
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias, Self, NotRequired, TypedDict
+
+    StrPath: TypeAlias = str | os.PathLike[str]
+
+    class _RTFDict(TypedDict):
+        atnum: int
+        mass: float
+        charge: NotRequired[float]
+        epsilon: NotRequired[float]
+        sigma: NotRequired[float]
+
+__all__ = ["create_top"]
+
+
+class _FileIter(Iterator[str]):
+    """Enumerate through the passed ``iterable`` and remove all empty and commented lines."""
+
+    __slots__ = ("__weakref__", "_enumerator", "_name", "_index")
+
+    _name: str
+    _index: None | int
+
+    @property
+    def index(self) -> None | int:
+        """Get the index within the current iterator."""
+        return self._index
+
+    @property
+    def name(self) -> str:
+        """Get the name of the iterator."""
+        return self._name
+
+    def __init__(self, iterable: Iterable[str], start=1) -> None:
+        self._enumerator = ((i, j.strip()) for i, j in enumerate(iterable, start=start))
+        self._name = getattr(iterable, "name", "<unknown>")
+        self._index = None
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> str:
+        self._index, value = next(self._enumerator)
+        return value
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} name={self._name!r} index={self._index!r}>"
+
+
+def _parse_rtf(file: Iterator[str]) -> dict[str, _RTFDict]:
+    file_iter = _FileIter(file)
+    prefix = f"Error parsing {file_iter.name!r}"
+    dct: dict[str, _RTFDict] = {}
+
+    try:
+        i = next(file_iter)
+        while not i.startswith("MASS"):
+            i = next(file_iter)
+    except StopIteration:
+        raise ValueError(f'{prefix}: Failed to find any "MASS" blocks')
+
+    while i.startswith("MASS"):
+        args = i.partition("!")[0].split()
+        if len(args) != 5:
+            raise ValueError(
+                f'{prefix}: Expected 5 columns in the "MASS" mass block at line {file_iter.index}'
+            )
+        dct[args[2]] = {"atnum": PT.get_atomic_number(args[4]), "mass": float(args[3])}
+        i = next(file_iter)
+
+    try:
+        i = next(file_iter)
+        while not i.startswith("ATOM"):
+            i = next(file_iter)
+    except StopIteration:
+        raise ValueError(f'{prefix}: Failed to find any "ATOM" blocks')
+
+    iterator = (i.partition("!")[0].split() for i in file_iter if i.startswith("ATOM"))
+    for args in iterator:
+        if len(args) != 4:
+            raise ValueError(
+                f'{prefix}: Expected 4 columns in the "ATOM" mass block at line {file_iter.index}'
+            )
+        atom_name, charge = args[2], float(args[3])
+        charge_old = dct[atom_name].get("charge")
+        if charge_old is not None and charge_old != charge:
+            raise ValueError(
+                f'{prefix}: Found multiple distinct charges for atom type {atom_name!r}: '
+                f'{charge} and {charge_old}'
+            )
+        dct[atom_name]["charge"] = charge
+    return dct
+
+
+def create_top(
+    out_path: StrPath,
+    *,
+    rtf_files: Iterable[StrPath],
+    prm_files: Iterable[StrPath | FOX.PRMContainer],
+) -> None:
+    """Construct a GROMACS .top file from the passed CHARMM .rtf and .prm files.
+
+    Parameters
+    ----------
+    out_path : :term:`python:path-like`
+        The name of the to-be created output file. Will be overriden if it already exists
+    rtf_files : list of :term:`python:path-like` objects
+        The names of all to-be converted .rtf files
+    prm_files : list of :term:`python:path-like` and/or :class:`FOX.PRMContainer` objects
+        The names of all to-be converted .prm files
+
+    """
+    with open(out_path, "w", encoding="utf8") as f_out:
+        rtf_dict: dict[str, _RTFDict] = {}
+        for rtf_file in rtf_files:
+            with open(rtf_file, "r", encoding="utf8") as f_rtf:
+                rtf_dict.update(_parse_rtf(f_rtf))
+
+        prm_list: list[FOX.PRMContainer] = []
+        for _prm in prm_files:
+            prm = _prm if isinstance(_prm, FOX.PRMContainer) else FOX.PRMContainer.read(_prm)
+            prm_list.append(prm)
+            if prm.nonbonded is None:
+                raise ValueError
+            for atom_name, series in prm.nonbonded.iterrows():
+                rtf_dict[atom_name].update({
+                    "epsilon": series[2],
+                    "sigma": series[3] * 2 / 2**(1/6),
+                })
+
+        f_out.write("[ defaults ]\n")
+        f_out.write("1 2 yes 1.0 1.0\n")
+        f_out.write("\n[ atomtypes ]\n")
+        for atom_type, dct in rtf_dict.items():
+            f_out.write(
+                f"{atom_type:>4} {dct['atnum']:>3} {dct['mass']:>16.9f} {dct['charge']:>16.9f} "
+                f"A {dct['sigma']:>16.9f} {dct['epsilon']:>16.9f}\n"
+            )
+
+        f_out.write("\n[ bondtypes ]\n")
+        for prm in prm_list:
+            if prm.bonds is not None:
+                for ((at1, at2), series) in prm.bonds.iterrows():
+                    k = series[2]
+                    rij = series[3] / 10
+                    f_out.write(f"{at1:>4} {at2:>4} 1 {rij:>16.9f} {k:>16.9f}\n")
+
+        f_out.write("\n[ angletypes ]\n")
+        for prm in prm_list:
+            if prm.angles is not None:
+                for ((at1, at2, at3), series) in prm.angles.iterrows():
+                    k, theta, k_ub, rij_ub = series
+                    if not math.isnan(k_ub):
+                        f_out.write(
+                            f"{at1:>4} {at2:>4} {at3:>4} 5 {theta:>16.9f} "
+                            f"{k:>16.9f} {rij_ub:>16.9f} {k_ub:>16.9f}\n"
+                        )
+                    else:
+                        f_out.write(f"{at1:>4} {at2:>4} {at3:>4} 1 {theta:>16.9f} {k:>16.9f}\n")
+
+        f_out.write("\n[ dihedraltypes ]\n")
+        for prm in prm_list:
+            if prm.dihedrals is not None:
+                for ((at1, at2, at3, at4), series) in prm.dihedrals.iterrows():
+                    k, mult, phi = series
+                    f_out.write(
+                        f"{at1:>4} {at2:>4} {at3:>4} 9 {phi:>16.9f} {k:>16.9f} {mult:>2n}\n"
+                    )
+
+        f_out.write("\n[ dihedraltypes ]\n")
+        for prm in prm_list:
+            if prm.impropers is not None:
+                for ((at1, at2, at3, at4), series) in prm.impropers.iterrows():
+                    k, _, xi = series
+                    f_out.write(f"{at1:>4} {at2:>4} {at3:>4} 2 {xi:>16.9f} {k:>16.9f}\n")
+
+        f_out.write("\n[ nonbond_params ]\n")
+        for prm in prm_list:
+            if prm.nbfix is not None:
+                for ((at1, at2), series) in prm.nbfix.iterrows():
+                    epsilon = series[2]
+                    sigma = series[3] * 2 / 2**(1/6)
+                    f_out.write(f"{at1:>4} {at2:>4} 1 {sigma:>16.9f} {epsilon:>16.9f}\n")

--- a/docs/7_recipes.rst
+++ b/docs/7_recipes.rst
@@ -9,6 +9,7 @@ Various recipes implemented in Auto-FOX.
     FOX.recipes.ligands
     FOX.recipes.time_resolution
     FOX.recipes.similarity
+    FOX.recipes.top
 
 FOX.recipes.param
 -----------------
@@ -29,3 +30,7 @@ FOX.recipes.time_resolution
 FOX.recipes.similarity
 ----------------------
 .. automodule:: FOX.recipes.similarity
+
+FOX.recipes.top
+---------------
+.. automodule:: FOX.recipes.create_top


### PR DESCRIPTION
Work in progress for adding a recipe that converts CHARMM .rtf & .prm files into a GROMACS .top file.

The workflow is currently limited to writing directives at the parameter level; support for system- and molecule-directives will follow shortly.