### PR TITLE
ENH: Add basic support for writing .top file molecule and system directives

### DIFF
--- a/FOX/recipes/top.py
+++ b/FOX/recipes/top.py
@@ -15,22 +15,31 @@ API
 from __future__ import annotations
 
 import os
+import operator
 import sys
 import math
-from collections.abc import Iterable
+import functools
+import itertools
+from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING
 
-from scm.plams import PT
+from scm.plams import PT, Molecule
 
 import FOX
+from FOX.functions.molecule_utils import get_bonds, get_angles, get_dihedrals, get_impropers
 
 if sys.version_info >= (3, 9):
     from collections.abc import Iterator
 else:
     from typing import Iterator
 
+if TYPE_CHECKING or sys.version_info < (3, 10):
+    from builtins import zip as strict_zip
+else:
+    strict_zip = functools.partial(zip, strict=True)
+
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias, Self, NotRequired, TypedDict
+    from typing_extensions import TypeAlias, Self, NotRequired, TypedDict, SupportsIndex
 
     StrPath: TypeAlias = str | os.PathLike[str]
 
@@ -78,7 +87,7 @@ class _FileIter(Iterator[str]):
         return f"<{type(self).__name__} name={self._name!r} index={self._index!r}>"
 
 
-def _parse_rtf(file: Iterator[str]) -> dict[str, _RTFDict]:
+def _parse_rtf(file: Iterator[str]) -> tuple[list[str], dict[str, _RTFDict]]:
     file_iter = _FileIter(file)
     prefix = f"Error parsing {file_iter.name!r}"
     dct: dict[str, _RTFDict] = {}
@@ -100,19 +109,21 @@ def _parse_rtf(file: Iterator[str]) -> dict[str, _RTFDict]:
         i = next(file_iter)
 
     try:
-        i = next(file_iter)
         while not i.startswith("ATOM"):
             i = next(file_iter)
     except StopIteration:
         raise ValueError(f'{prefix}: Failed to find any "ATOM" blocks')
 
     iterator = (i.partition("!")[0].split() for i in file_iter if i.startswith("ATOM"))
-    for args in iterator:
+    atoms = []
+    for args in itertools.chain([i.partition("!")[0].split()], iterator):
         if len(args) != 4:
             raise ValueError(
                 f'{prefix}: Expected 4 columns in the "ATOM" mass block at line {file_iter.index}'
             )
+
         atom_name, charge = args[2], float(args[3])
+        atoms.append(atom_name)
         charge_old = dct[atom_name].get("charge")
         if charge_old is not None and charge_old != charge:
             raise ValueError(
@@ -120,12 +131,14 @@ def _parse_rtf(file: Iterator[str]) -> dict[str, _RTFDict]:
                 f'{charge} and {charge_old}'
             )
         dct[atom_name]["charge"] = charge
-    return dct
+    return atoms, dct
 
 
 def create_top(
     out_path: StrPath,
     *,
+    xyz_files: Mapping[str, StrPath | Molecule],
+    mol_count: Iterable[SupportsIndex],
     rtf_files: Iterable[StrPath],
     prm_files: Iterable[StrPath | FOX.PRMContainer],
 ) -> None:
@@ -133,8 +146,12 @@ def create_top(
 
     Parameters
     ----------
-    out_path : :term:`python:path-like`
+    out_path : :term:`python:path-like` object
         The name of the to-be created output file. Will be overriden if it already exists
+    xyz_files : dictionary of :term:`python:path-like` objects
+        A dictionary mapping residue names to .xyz files and/or plams molecules
+    mol_count : ``list[int]``
+        The number
     rtf_files : list of :term:`python:path-like` objects
         The names of all to-be converted .rtf files
     prm_files : list of :term:`python:path-like` and/or :class:`FOX.PRMContainer` objects
@@ -143,9 +160,12 @@ def create_top(
     """
     with open(out_path, "w", encoding="utf8") as f_out:
         rtf_dict: dict[str, _RTFDict] = {}
+        atom_types_list: list[list[str]] = []
         for rtf_file in rtf_files:
             with open(rtf_file, "r", encoding="utf8") as f_rtf:
-                rtf_dict.update(_parse_rtf(f_rtf))
+                atom_names, _rtf_dct = _parse_rtf(f_rtf)
+                atom_types_list.append(atom_names)
+                rtf_dict.update(_rtf_dct)
 
         prm_list: list[FOX.PRMContainer] = []
         for _prm in prm_files:
@@ -212,3 +232,46 @@ def create_top(
                     epsilon = series[2]
                     sigma = series[3] * 2 / 2**(1/6)
                     f_out.write(f"{at1:>4} {at2:>4} 1 {sigma:>16.9f} {epsilon:>16.9f}\n")
+
+        enumerator = enumerate(strict_zip(atom_types_list, xyz_files.items()), start=1)
+        for i, (atom_types, (res_name, xyz)) in enumerator:
+            mol = Molecule(xyz) if not isinstance(xyz, Molecule) else xyz
+            if not mol.bonds:
+                mol.guess_bonds()
+            f_out.write("\n[ moleculetype ]\n")
+            f_out.write(f"molecule{i:<5n} 3\n")
+
+            f_out.write("\n[ atoms ]\n")
+            for j, (at, at_name) in enumerate(strict_zip(mol, atom_types), start=1):
+                charge, mass = rtf_dict[at_name]["charge"], rtf_dict[at_name]["mass"]
+                f_out.write(
+                    f"{j:>5n} {at_name:>4} 1 {res_name:>4} {at.symbol:>2} {1:>5n} "
+                    f"{charge:>16.9f} {mass:>16.9f}\n"
+                )
+
+            bonds = get_bonds(mol)
+            f_out.write("\n[ bonds ]\n")
+            for at_i, at_j in bonds:
+                f_out.write(f"{at_i:>5n} {at_j:>5n} {1:>5n}\n")
+
+            angles = get_angles(mol)
+            f_out.write("\n[ angles ]\n")
+            for at_i, at_j, at_k in angles:
+                f_out.write(f"{at_i:>5n} {at_j:>5n} {at_k:>5n} {1:>5n}\n")
+
+            dihedrals = get_dihedrals(mol)
+            f_out.write("\n[ dihedrals ]\n")
+            for at_i, at_j, at_k, at_l in dihedrals:
+                f_out.write(f"{at_i:>5n} {at_j:>5n} {at_k:>5n} {at_l:>5n} {9:>5n}\n")
+
+            impropers = get_impropers(mol)
+            f_out.write("\n[ dihedrals ]\n")
+            for at_i, at_j, at_k, at_l in impropers:
+                f_out.write(f"{at_i:>5n} {at_j:>5n} {at_k:>5n} {at_l:>5n} {2:>5n}\n")
+
+        f_out.write("\n[ system ]\n")
+        f_out.write("system1\n")
+
+        f_out.write("\n[ molecules ]\n")
+        for i, k in enumerate(mol_count, start=1):
+            f_out.write(f"molecule{i:<5n} {operator.index(k)}\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ filterwarnings = [
     "ignore:Generic keyword '_pytestfixturefunction' not implemented for package \\w:qmflows.warnings_qmflows.Key_Warning",
     "ignore:`(product|cumproduct)` is deprecated as of NumPy 1\\.25\\.0, and will be removed in NumPy 2\\.0:DeprecationWarning:h5py",
     "ignore:`(product|cumproduct)` is deprecated as of NumPy 1\\.25\\.0, and will be removed in NumPy 2\\.0:DeprecationWarning:pandas",
+    "ignore:`(product|cumproduct)` is deprecated as of NumPy 1\\.25\\.0, and will be removed in NumPy 2\\.0:DeprecationWarning:FOX.io.hdf5_utils",
+    "ignore:`np\\.find_common_type is deprecated:DeprecationWarning:pandas",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
Follow up on https://github.com/nlesc-nano/auto-FOX/pull/287.

Now adds basic support for setting the molecule and system directives. Currently it uses the .xyz file for generating all bond/angle/dihedral/etc information, though in principle this _could_ be extracted from the CHARMM .rtf file as well.