### PR TITLE
ENH: Add a new recipe for interconverting between .gro and .xyz

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -76,7 +76,7 @@ jobs:
                     else
                         pip install -e .[test-no-optional]
                     fi
-                    pip install auto-FOX-data@git+https://github.com/nlesc-nano/auto-FOX-data@1.1.8
+                    pip install https://github.com/nlesc-nano/auto-FOX-data/releases/download/1.2.0/Auto_FOX_Data-1.2.0-py3-none-any.whl
 
             -   name: Info Python
                 run: |

--- a/FOX/classes/multi_mol_magic.py
+++ b/FOX/classes/multi_mol_magic.py
@@ -32,6 +32,14 @@ from scm.plams import PeriodicTable, PTError, Settings  # type: ignore
 from assertionlib.ndrepr import NDRepr
 from nanoutils import ArrayLike, Literal
 
+
+class AliasTuple(NamedTuple):
+    """A 2-tuple used for :attr:`FOX.MultiMolecule.atoms` values."""
+
+    alias: str
+    slice: Union[slice, ellipsis, np.ndarray[Any, np.dtype[np.intp]]]  # noqa: F821
+
+
 if TYPE_CHECKING:
     import numpy.typing as npt
 
@@ -46,14 +54,6 @@ if TYPE_CHECKING:
     AliasMapping = Mapping[str, Tuple[str, Union[slice, ellipsis, _ArLikeInt]]]  # noqa: F821
 
 __all__: List[str] = ["_MultiMolecule", "AliasTuple"]
-
-
-class AliasTuple(NamedTuple):
-    """A 2-tuple used for :attr:`FOX.MultiMolecule.atoms` values."""
-
-    alias: str
-    slice: Union[slice, ellipsis, np.ndarray[Any, np.dtype[np.intp]]]  # noqa: F821
-
 
 T = TypeVar('T')
 MT = TypeVar('MT', bound='_MultiMolecule')

--- a/FOX/recipes/__init__.py
+++ b/FOX/recipes/__init__.py
@@ -6,12 +6,14 @@ from .ligands import get_lig_center, get_multi_lig_center
 from .time_resolution import time_resolved_adf, time_resolved_rdf
 from .similarity import compare_trajectories, fps_reduce
 from .top import create_top
+from ._xyz_to_gro import gro_to_xyz, xyz_to_gro
 
 __all__ = [
-    'get_best', 'overlay_descriptor', 'plot_descriptor',
-    'generate_psf', 'generate_psf2', 'extract_ligand',
-    'get_lig_center', 'get_multi_lig_center',
-    'time_resolved_adf', 'time_resolved_rdf',
-    'compare_trajectories', 'fps_reduce',
-    'create_top',
+    "get_best", "overlay_descriptor", "plot_descriptor",
+    "generate_psf", "generate_psf2", "extract_ligand",
+    "get_lig_center", "get_multi_lig_center",
+    "time_resolved_adf", "time_resolved_rdf",
+    "compare_trajectories", "fps_reduce",
+    "create_top",
+    "gro_to_xyz", "xyz_to_gro",
 ]

--- a/FOX/recipes/_xyz_to_gro.py
+++ b/FOX/recipes/_xyz_to_gro.py
@@ -1,0 +1,116 @@
+"""Interconvert between .xyz and .gro files.
+
+Examples
+--------
+This recipe is available from the command line via the ``FOX.recipes.xyz_to_gro`` entry point:
+
+.. code:: bash
+
+    > FOX.recipes.xyz_to_gro file.xyz file.gro
+
+
+Index
+-----
+.. currentmodule:: FOX.recipes
+.. autosummary::
+    xyz_to_gro
+    gro_to_xyz
+
+API
+---
+.. autofunction:: xyz_to_gro
+.. autofunction:: gro_to_xyz
+
+"""
+
+from __future__ import annotations
+
+import os
+import argparse
+import itertools
+import warnings
+
+import FOX
+from FOX.utils import LicenseAction
+
+__all__ = ["xyz_to_gro", "gro_to_xyz"]
+
+
+def xyz_to_gro(
+    xyz_path: str | os.PathLike[str] | FOX.MultiMolecule,
+    gro_path: str | os.PathLike[str],
+) -> None:
+    """Convert the passed .xyz file into a .gro file.
+
+    Parameters
+    ----------
+    xyz_path : path-like object
+        The name of the to-be read .xyz file.
+    gro_path : path-like object
+        The name of the to-be created .gro file.
+
+    """
+    if isinstance(xyz_path, FOX.MultiMolecule):
+        mol = xyz_path
+    else:
+        mol = FOX.MultiMolecule.from_xyz(xyz_path, read_comment=True)
+
+    if mol.shape[1] != 1:
+        warnings.warn(
+            "The passed .xyz contains multiple molecules; "
+            "only the first will be written to the .gro file"
+        )
+    mol.as_gro(gro_path)
+
+
+def gro_to_xyz(
+    gro_path: str | os.PathLike[str],
+    xyz_path: str | os.PathLike[str],
+) -> None:
+    """Convert the passed .xyz file into a .gro file.
+
+    Parameters
+    ----------
+    gro_path : path-like object
+        The name of the to-be created .gro file.
+    xyz_path : path-like object
+        The name of the to-be read .xyz file.
+
+    """
+    with open(gro_path, "r", encoding="utf8") as f_inp, open(xyz_path, "w", encoding="utf8") as f_out:  # noqa: E501
+        header = next(f_inp)
+        atom_count_str = next(f_inp)
+        try:
+            atom_count = int(atom_count_str)
+        except ValueError as ex:
+            raise ValueError(f"Invalid atom count: {atom_count_str}") from ex
+
+        f_out.write(f"{atom_count_str}")
+        f_out.write(f"{header}")
+        for item in itertools.islice(f_inp, atom_count):
+            f_out.write(f"{item[10:15]} {item[20:44]}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        usage="FOX.recipes.xyz_to_gro file.xyz file.gro",
+        description=__doc__ if __doc__ is None else __doc__.split("\n")[0],
+    )
+    parser.add_argument("--license", dest="license", action=LicenseAction)
+    parser.add_argument("--version", action="version", version=f"%(prog)s {FOX.__version__}")
+    parser.add_argument("xyz_path", help="The .xyz file")
+    parser.add_argument("gro_path", help="The .gro file")
+    parser.add_argument(
+        "--gro_to_xyz", action="store_true",
+        help="Whether to convert the .gro file into .xyz rather than the other way around"
+    )
+
+    args = parser.parse_args()
+    if args.gro_to_xyz:
+        gro_to_xyz(args.gro_path, args.xyz_path)
+    else:
+        xyz_to_gro(args.xyz_path, args.gro_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/FOX/utils.py
+++ b/FOX/utils.py
@@ -36,6 +36,7 @@ API
 from __future__ import annotations
 
 import os
+import argparse
 import operator
 import inspect
 import textwrap
@@ -60,6 +61,7 @@ __all__ = [
     'get_move_range', 'array_to_index', 'serialize_array', 'read_str_file',
     'get_shape', 'slice_str', 'get_atom_count', 'read_rtf_file', 'prepend_exception',
     'log_traceback_locals', 'slice_iter', 'lattice_to_volume', 'get_commit_hash',
+    'LicenseAction',
 ]
 
 T = TypeVar('T')
@@ -550,3 +552,44 @@ def get_commit_hash(path: str | os.PathLike[str]) -> str | None:
         return None
     else:
         return out.stdout.strip("\n")
+
+
+class LicenseAction(argparse.Action):
+    """Custom action for displaying license info."""
+
+    LICENSE = textwrap.dedent(
+        """
+        Copyright 2023 Nanomaterial Simulation Packages (https://github.com/nlesc-nano)
+
+        Licensed under the GNU Lesser General Public License v3 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            https://www.gnu.org/licenses/gpl-3.0.en.html
+            https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    """)  # noqa: E501
+
+    def __init__(
+        self,
+        option_strings,
+        dest=argparse.SUPPRESS,
+        default=argparse.SUPPRESS,
+        help="show program's license and exit",
+    ):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs=0,
+            help=help,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(self.LICENSE)
+        parser.exit()

--- a/docs/7_recipes.rst
+++ b/docs/7_recipes.rst
@@ -34,3 +34,7 @@ FOX.recipes.similarity
 FOX.recipes.top
 ---------------
 .. automodule:: FOX.recipes.top
+
+FOX.recipes.xyz_to_gro
+----------------------
+.. automodule:: FOX.recipes._xyz_to_gro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
 [project.scripts]
 init_armc = "FOX.entry_points:main_armc"
 armc2yaml = "FOX.entry_points:main_armc2yaml"
+"FOX.recipes.xyz_to_gro" = "FOX.recipes._xyz_to_gro:main"
 
 [project.urls]
 Homepage = "https://github.com/nlesc-nano/Auto-FOX"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ test = [
 test-no-optional = [
     "pytest>=6.0.0",
     "pytest-cov",
+    "numpy>=1.17.3,<1.25",
 ]
 
 [tool.setuptools]

--- a/tests/test_xyz_to_gro.py
+++ b/tests/test_xyz_to_gro.py
@@ -1,0 +1,20 @@
+import pathlib
+
+import pytest
+import numpy as np
+from FOX.recipes import xyz_to_gro, gro_to_xyz
+from FOX import MultiMolecule, example_xyz
+
+
+def test_xyz_to_gro(tmp_path: pathlib.Path) -> None:
+    gro_file = tmp_path / "xyz_to_gro.gro"
+    xyz_file = tmp_path / "gro_to_xyz.xyz"
+
+    mol_ref = MultiMolecule.from_xyz(example_xyz)
+    with pytest.warns(Warning, match="contains multiple molecules"):
+        xyz_to_gro(mol_ref, gro_file)
+    gro_to_xyz(gro_file, xyz_file)
+    mol = MultiMolecule.from_xyz(xyz_file)
+
+    np.testing.assert_allclose(mol[0], mol_ref[0], atol=1e-3, rtol=0)
+    np.testing.assert_array_equal(mol_ref.symbol, mol.symbol)


### PR DESCRIPTION
Closes https://github.com/nlesc-nano/auto-FOX/issues/292

Adds a new recipe for converting .xyz to .gro files and vice versa.

Examples
---------
Available under the `FOX.recipes` namespace:
``` python
from FOX.recipes import gro_to_xyz, xyz_to_gro

gro_file: str = ...
xyz_file: str = ...
gro_to_xyz(gro_file, xyz_file)
xyz_to_gro(xyz_file, gro_file)
```

Also available directly from the command line via the `FOX.recipes.xyz_to_gro` entry point:

```shell
> FOX.recipes.xyz_to_gro file.xyz file.gro
```